### PR TITLE
Add Fortnite-themed portfolio site with interactive island map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,15 @@ Two sites live in this repo:
 - **Root (`index.html`, `styles.css`, `script.js`)** — the classic portfolio, served by
   GitHub Pages from `main`. Keep it untouched unless Ali explicitly asks to change it.
 - **`fortnite/`** — the Fortnite-themed portfolio (vanilla HTML/CSS/JS, no build step).
-  It loads the real Chapter 1 Season 7 map at runtime from the public
+  It loads the real Fortnite Reload island (codename BlastBerry,
+  `latest/blastberry_latest.png`) at runtime from the public
   `yaelbrinkert/fortnite-archives` project and falls back to an original hand-drawn SVG
   island if that image can't load. Do not commit Epic Games imagery into this repo, and
   keep the Epic fan-content disclaimer visible on the page.
+  Content mirrors Ali's resume: Visa (SWE, Jun 2026–), Cronys co-founder (Mar 2026–),
+  Vantor, CUChange, ReportsNow; CU Boulder grad May 2026 (GPA 3.7). Update panels when
+  Ali shares a new resume. His phone number stays OFF the site (spam), even though it
+  is on the resume.
 
 ## Design rules (Ali's preferences — apply to all future work here)
 
@@ -17,8 +22,13 @@ Two sites live in this repo:
   gradient text). Use flat colors, hard-edged offset shadows (`box-shadow`/`text-shadow`
   with no blur), angled `clip-path` corners, and hard-stop stripe patterns. This matches
   the flat look of actual Fortnite UI.
-- Display font: Anton (closest free stand-in for Fortnite's Burbank), uppercase, often
-  with a slight `skewX`. Body font: Inter.
+- Display font: Anton (closest free stand-in for Fortnite's Burbank Big Condensed —
+  the real Burbank is commercial and must never be embedded from pirate mirrors),
+  uppercase, often with a slight `skewX`. Body font: Inter.
+- Palette is pinned in `fortnite/styles.css` `:root`: ocean `#103a8c` and grass
+  `#318218` sampled from the map texture; Fortnite-standard rarity colors
+  (mythic `#fbd444`, legendary `#ea8d23`, epic `#c359ff`, rare `#41bfff`,
+  uncommon `#87e339`, common `#b1b1b1`); CTA yellow `#fff200`; storm `#b04df9`.
 - Aim for authentic game-UI styling over generic web styling.
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Ali's Portfolio Repo
+
+Two sites live in this repo:
+
+- **Root (`index.html`, `styles.css`, `script.js`)** — the classic portfolio, served by
+  GitHub Pages from `main`. Keep it untouched unless Ali explicitly asks to change it.
+- **`fortnite/`** — the Fortnite-themed portfolio (vanilla HTML/CSS/JS, no build step).
+  It loads the real Chapter 1 Season 7 map at runtime from the public
+  `yaelbrinkert/fortnite-archives` project and falls back to an original hand-drawn SVG
+  island if that image can't load. Do not commit Epic Games imagery into this repo, and
+  keep the Epic fan-content disclaimer visible on the page.
+
+## Design rules (Ali's preferences — apply to all future work here)
+
+- **No emojis in UI.** Use inline SVG icons (see the icon sprite in `fortnite/index.html`).
+- **No gradient blends** (no purple-to-blue heroes, no glossy gradient buttons or
+  gradient text). Use flat colors, hard-edged offset shadows (`box-shadow`/`text-shadow`
+  with no blur), angled `clip-path` corners, and hard-stop stripe patterns. This matches
+  the flat look of actual Fortnite UI.
+- Display font: Anton (closest free stand-in for Fortnite's Burbank), uppercase, often
+  with a slight `skewX`. Body font: Inter.
+- Aim for authentic game-UI styling over generic web styling.
+
+## Testing
+
+`python3 -m http.server 8000` from the repo root, then `http://localhost:8000/fortnite/`.
+The sandbox browser can't reach external hosts; to test the real-map mode locally,
+download the map JPG elsewhere, serve it, and open
+`/fortnite/?mapimg=<local-url>` (the override exists for exactly this).
+Verify UI changes with Playwright screenshots (Chromium at `/opt/pw-browsers/chromium`).

--- a/fortnite/index.html
+++ b/fortnite/index.html
@@ -13,6 +13,60 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <!-- ============ ICON SPRITE ============ -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <symbol id="i-mail" viewBox="0 0 24 24">
+          <rect x="2.5" y="5" width="19" height="14" rx="2" fill="none" stroke="currentColor" stroke-width="2" />
+          <path d="M 3.5 7 L 12 13.5 L 20.5 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </symbol>
+        <symbol id="i-code" viewBox="0 0 24 24">
+          <path d="M 8.5 7 L 3.5 12 L 8.5 17 M 15.5 7 L 20.5 12 L 15.5 17" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M 13.2 5.5 L 10.8 18.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+        </symbol>
+        <symbol id="i-globe" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2" />
+          <ellipse cx="12" cy="12" rx="4" ry="9" fill="none" stroke="currentColor" stroke-width="1.8" />
+          <path d="M 3.5 12 h 17" stroke="currentColor" stroke-width="1.8" />
+        </symbol>
+        <symbol id="i-pad" viewBox="0 0 24 24">
+          <path d="M 7 8 h 10 a 5 5 0 0 1 5 5 c 0 3 -2 5 -4 4.4 L 15 15.5 H 9 L 6 17.4 C 4 18 2 16 2 13 a 5 5 0 0 1 5 -5 Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+          <path d="M 8 11 v 3 M 6.5 12.5 h 3" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+          <circle cx="16" cy="11.6" r="1.1" fill="currentColor" />
+          <circle cx="18.4" cy="13.4" r="1.1" fill="currentColor" />
+        </symbol>
+        <symbol id="i-user" viewBox="0 0 24 24">
+          <circle cx="12" cy="8" r="4" fill="none" stroke="currentColor" stroke-width="2" />
+          <path d="M 4.5 20 a 7.5 6.5 0 0 1 15 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+        </symbol>
+        <symbol id="i-pin" viewBox="0 0 24 24">
+          <path d="M 12 21.5 C 12 21.5 5 14.5 5 9.5 a 7 7 0 0 1 14 0 C 19 14.5 12 21.5 12 21.5 Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+          <circle cx="12" cy="9.5" r="2.6" fill="currentColor" />
+        </symbol>
+        <symbol id="i-check" viewBox="0 0 24 24">
+          <path d="M 4.5 12.5 L 10 18 L 19.5 6.5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+        </symbol>
+        <symbol id="i-out" viewBox="0 0 24 24">
+          <path d="M 8 6 h 10 v 10 M 18 6 L 6 18" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" />
+        </symbol>
+        <symbol id="i-x" viewBox="0 0 24 24">
+          <path d="M 6 6 L 18 18 M 18 6 L 6 18" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" />
+        </symbol>
+        <!-- battle bus, shared by both map modes -->
+        <symbol id="busShape" viewBox="-45 -100 90 120">
+          <path d="M 0 -46 Q -34 -78 0 -92 Q 34 -78 0 -46 Z" fill="#8547e8" stroke="#5a1fd0" stroke-width="3" />
+          <line x1="-14" y1="-52" x2="-10" y2="-24" stroke="#2a2a2a" stroke-width="2.5" />
+          <line x1="14" y1="-52" x2="10" y2="-24" stroke="#2a2a2a" stroke-width="2.5" />
+          <rect x="-38" y="-24" width="76" height="34" rx="8" fill="#4f78d9" stroke="#2d4fa3" stroke-width="3" />
+          <rect x="-30" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
+          <rect x="-9" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
+          <rect x="12" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
+          <circle cx="-22" cy="12" r="7" fill="#222" />
+          <circle cx="22" cy="12" r="7" fill="#222" />
+        </symbol>
+      </defs>
+    </svg>
+
     <!-- ============ LOBBY / LOADING SCREEN ============ -->
     <div id="lobby" class="lobby">
       <div class="lobby-sky"></div>
@@ -25,7 +79,7 @@
         </button>
         <a class="lobby-classic" href="../index.html">or switch to Classic Mode</a>
       </div>
-      <div class="lobby-tip">TIP: Click a POI on the map to discover a part of Ali. Find all 6 for a Victory Royale.</div>
+      <div class="lobby-tip">TIP: Drop into a POI to discover a part of Ali. Clear all 6 for a Victory Royale.</div>
     </div>
 
     <!-- ============ GAME / MAP SCREEN ============ -->
@@ -43,14 +97,17 @@
       <!-- HUD: right column -->
       <div class="hud-right">
         <div class="minimap" aria-hidden="true">
-          <svg viewBox="0 0 1600 1000" preserveAspectRatio="xMidYMid slice">
+          <img id="miniImg" alt="" hidden />
+          <svg id="miniFallback" viewBox="0 0 1600 1000" preserveAspectRatio="xMidYMid slice">
             <use href="#islandArt" />
-            <circle id="miniStorm" cx="800" cy="500" r="620" class="storm-ring" />
+          </svg>
+          <svg class="mini-overlay" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <circle id="miniStorm" cx="50" cy="50" r="46" />
           </svg>
         </div>
         <div class="hud-stats">
-          <div class="hud-stat"><span class="hud-ico">👤</span> 1 recruiter watching</div>
-          <div class="hud-stat"><span class="hud-ico">📍</span> <span id="poiCount">0</span>/6 POIs discovered</div>
+          <div class="hud-stat"><svg class="ico"><use href="#i-user" /></svg> 1 recruiter watching</div>
+          <div class="hud-stat"><svg class="ico"><use href="#i-pin" /></svg> <span id="poiCount">0</span>/6 POIs cleared</div>
         </div>
       </div>
 
@@ -62,38 +119,62 @@
 
       <!-- HUD: bottom right hotbar -->
       <div class="hotbar">
-        <a class="slot" href="mailto:ali.haroon@colorado.edu" title="Email Ali">✉️<em>Email</em></a>
-        <a class="slot" href="https://github.com/Ali-Haroon3" target="_blank" rel="noreferrer" title="GitHub">🐙<em>GitHub</em></a>
-        <a class="slot" href="https://www.ali-haroon.com" target="_blank" rel="noreferrer" title="Main site">🌐<em>Site</em></a>
-        <a class="slot" href="../index.html" title="Classic portfolio">🕹️<em>Classic</em></a>
+        <a class="slot" href="mailto:ali.haroon@colorado.edu" title="Email Ali"><svg class="ico"><use href="#i-mail" /></svg><em>Email</em></a>
+        <a class="slot" href="https://github.com/Ali-Haroon3" target="_blank" rel="noreferrer" title="GitHub"><svg class="ico"><use href="#i-code" /></svg><em>GitHub</em></a>
+        <a class="slot" href="https://www.ali-haroon.com" target="_blank" rel="noreferrer" title="Main site"><svg class="ico"><use href="#i-globe" /></svg><em>Site</em></a>
+        <a class="slot" href="../index.html" title="Classic portfolio"><svg class="ico"><use href="#i-pad" /></svg><em>Classic</em></a>
       </div>
 
-      <!-- ============ THE ISLAND MAP ============ -->
-      <div class="map-wrap">
+      <!-- ============ REAL MAP MODE (Season 7 island via fortnite-archives) ============ -->
+      <div id="realStage" class="real-stage" hidden>
+        <div class="map-box">
+          <img id="mapImg" alt="Fortnite Chapter 1 Season 7 island map" draggable="false" />
+          <svg class="map-overlay" viewBox="0 0 4096 4096" preserveAspectRatio="none" aria-hidden="true">
+            <circle id="stormReal" cx="2048" cy="2048" r="2400" class="storm-line" />
+            <use id="busReal" href="#busShape" width="240" height="320" x="-120" y="-260" opacity="0" />
+          </svg>
+          <!-- hotspots: positions read off the 4096px map -->
+          <button class="spot" data-poi="experience" style="--x:37.5%; --y:48%">
+            <span class="spot-ring"></span>
+            <span class="spot-name">TILTED TOWERS</span>
+            <span class="spot-tag">EXPERIENCE</span>
+          </button>
+          <button class="spot" data-poi="projects" style="--x:26.5%; --y:29%">
+            <span class="spot-ring"></span>
+            <span class="spot-name">PLEASANT PARK</span>
+            <span class="spot-tag">PROJECTS</span>
+          </button>
+          <button class="spot" data-poi="skills" style="--x:52.5%; --y:61%">
+            <span class="spot-ring"></span>
+            <span class="spot-name">SALTY SPRINGS</span>
+            <span class="spot-tag">SKILLS</span>
+          </button>
+          <button class="spot" data-poi="contact" style="--x:43%; --y:37%">
+            <span class="spot-ring"></span>
+            <span class="spot-name">LOOT LAKE</span>
+            <span class="spot-tag">CONTACT</span>
+          </button>
+          <button class="spot" data-poi="education" style="--x:14%; --y:52.8%">
+            <span class="spot-ring"></span>
+            <span class="spot-name">POLAR PEAK</span>
+            <span class="spot-tag">EDUCATION</span>
+          </button>
+          <button class="spot" data-poi="about" style="--x:71%; --y:19%">
+            <span class="spot-ring"></span>
+            <span class="spot-name">RISKY REELS</span>
+            <span class="spot-tag">ABOUT ME</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- ============ FALLBACK MAP (original artwork, used if the real map can't load) ============ -->
+      <div id="fallbackStage" class="map-wrap" hidden>
         <svg id="mapSvg" viewBox="0 0 1600 1000" preserveAspectRatio="xMidYMid meet" role="group" aria-label="Island map of Ali's portfolio">
           <defs>
-            <radialGradient id="oceanGrad" cx="50%" cy="45%" r="75%">
-              <stop offset="0%" stop-color="#2e9fd9" />
-              <stop offset="70%" stop-color="#1b6fb5" />
-              <stop offset="100%" stop-color="#124f8c" />
-            </radialGradient>
-            <linearGradient id="grassGrad" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stop-color="#8ecf62" />
-              <stop offset="100%" stop-color="#6fb04a" />
-            </linearGradient>
-            <linearGradient id="towerGrad" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stop-color="#b9c6d8" />
-              <stop offset="100%" stop-color="#8494ab" />
-            </linearGradient>
-            <linearGradient id="stormGrad" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stop-color="#b44ee8" />
-              <stop offset="100%" stop-color="#7b2ff7" />
-            </linearGradient>
             <filter id="dropSh" x="-20%" y="-20%" width="140%" height="140%">
               <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#0a2a4a" flood-opacity="0.35" />
             </filter>
 
-            <!-- Reusable tree -->
             <g id="tree">
               <rect x="-3" y="6" width="6" height="10" rx="2" fill="#8a5a33" />
               <circle cx="0" cy="0" r="12" fill="#3f8f3d" />
@@ -101,14 +182,11 @@
               <circle cx="8" cy="6" r="8" fill="#4aa348" />
             </g>
 
-            <!-- The island artwork, reused by the minimap -->
             <g id="islandArt">
-              <rect x="0" y="0" width="1600" height="1000" fill="url(#oceanGrad)" />
-              <!-- wave rings -->
+              <rect x="0" y="0" width="1600" height="1000" fill="#1f7ac9" />
               <circle cx="800" cy="500" r="560" fill="none" stroke="#ffffff" stroke-opacity="0.08" stroke-width="18" />
               <circle cx="800" cy="500" r="640" fill="none" stroke="#ffffff" stroke-opacity="0.05" stroke-width="14" />
 
-              <!-- main island: sand then grass -->
               <path d="M 380 300
                        C 420 180, 620 120, 800 150
                        C 980 175, 1180 190, 1280 320
@@ -124,30 +202,26 @@
                        C 1128 800, 962 866, 800 848
                        C 634 830, 500 790, 424 672
                        C 350 552, 368 428, 410 320 Z"
-                    fill="url(#grassGrad)" />
+                    fill="#79b74f" />
 
-              <!-- spawn island (offshore) -->
               <ellipse cx="200" cy="775" rx="105" ry="72" fill="#e8d29a" />
-              <ellipse cx="200" cy="770" rx="88" ry="58" fill="url(#grassGrad)" />
+              <ellipse cx="200" cy="770" rx="88" ry="58" fill="#79b74f" />
 
-              <!-- lake -->
               <path d="M 1000 350 C 1060 320, 1160 330, 1190 390 C 1220 450, 1180 510, 1110 520 C 1035 530, 970 490, 965 435 C 962 395, 965 370, 1000 350 Z"
                     fill="#2e9fd9" stroke="#e8d29a" stroke-width="8" />
               <ellipse cx="1080" cy="428" rx="26" ry="16" fill="#e8d29a" />
 
-              <!-- river from lake to south shore -->
               <path d="M 990 470 C 940 560, 950 640, 905 700 C 870 748, 850 790, 845 850"
                     fill="none" stroke="#2e9fd9" stroke-width="20" stroke-linecap="round" />
 
-              <!-- roads -->
-              <g fill="none" stroke="#d9c48f" stroke-width="14" stroke-linecap="round" stroke-dasharray="none" opacity="0.9">
+              <g fill="none" stroke="#d9c48f" stroke-width="14" stroke-linecap="round" opacity="0.9">
                 <path d="M 620 290 C 680 360, 740 430, 800 505" />
                 <path d="M 800 505 C 900 560, 900 660, 905 730" />
                 <path d="M 800 505 C 890 480, 960 460, 1035 445" />
                 <path d="M 360 400 C 460 430, 640 480, 780 510" />
               </g>
 
-              <!-- Boulder Bluffs mountains -->
+              <!-- Polar Peak mountains -->
               <g transform="translate(330,370)">
                 <path d="M -80 60 L -10 -70 L 55 60 Z" fill="#9aa7b8" />
                 <path d="M -10 -70 L -34 -20 L 14 -20 Z" fill="#f2f6fa" />
@@ -155,7 +229,7 @@
                 <path d="M 70 -35 L 52 0 L 88 0 Z" fill="#eef3f8" />
               </g>
 
-              <!-- Pleasant Projects houses -->
+              <!-- Pleasant Park houses -->
               <g transform="translate(620,235)">
                 <g filter="url(#dropSh)">
                   <rect x="-55" y="0" width="44" height="34" fill="#e5eef7" />
@@ -165,12 +239,12 @@
                 </g>
               </g>
 
-              <!-- Tilted Tech Towers -->
+              <!-- Tilted Towers -->
               <g transform="translate(800,500)" filter="url(#dropSh)">
-                <rect x="-58" y="-70" width="34" height="88" fill="url(#towerGrad)" transform="rotate(-4 -41 -26)" />
-                <rect x="-14" y="-98" width="40" height="116" fill="url(#towerGrad)" />
-                <rect x="34" y="-58" width="30" height="76" fill="url(#towerGrad)" transform="rotate(4 49 -20)" />
-                <g fill="#ffd54d">
+                <rect x="-58" y="-70" width="34" height="88" fill="#9fb0c4" transform="rotate(-4 -41 -26)" />
+                <rect x="-14" y="-98" width="40" height="116" fill="#9fb0c4" />
+                <rect x="34" y="-58" width="30" height="76" fill="#9fb0c4" transform="rotate(4 49 -20)" />
+                <g fill="#ffd21f">
                   <rect x="-8" y="-88" width="8" height="8" /><rect x="8" y="-88" width="8" height="8" />
                   <rect x="-8" y="-68" width="8" height="8" /><rect x="8" y="-48" width="8" height="8" />
                   <rect x="-52" y="-58" width="7" height="7" /><rect x="-40" y="-38" width="7" height="7" />
@@ -178,7 +252,7 @@
                 </g>
               </g>
 
-              <!-- Salty Skills Springs -->
+              <!-- Salty Springs -->
               <g transform="translate(905,755)">
                 <ellipse cx="-30" cy="10" rx="26" ry="14" fill="#57c7e8" stroke="#e8d29a" stroke-width="5" />
                 <ellipse cx="34" cy="-4" rx="20" ry="11" fill="#57c7e8" stroke="#e8d29a" stroke-width="5" />
@@ -192,10 +266,9 @@
               <g transform="translate(1080,420)" filter="url(#dropSh)">
                 <rect x="-16" y="-10" width="32" height="20" rx="3" fill="#a8642c" />
                 <path d="M -16 -10 Q 0 -26 16 -10 Z" fill="#c07a38" />
-                <rect x="-3" y="-8" width="6" height="16" fill="#ffd54d" />
+                <rect x="-3" y="-8" width="6" height="16" fill="#ffd21f" />
               </g>
 
-              <!-- trees scattered -->
               <use href="#tree" transform="translate(520,560)" />
               <use href="#tree" transform="translate(700,660) scale(0.85)" />
               <use href="#tree" transform="translate(1150,610) scale(0.9)" />
@@ -205,78 +278,75 @@
               <use href="#tree" transform="translate(450,520) scale(0.75)" />
               <use href="#tree" transform="translate(1100,700) scale(0.8)" />
 
-              <!-- spawn island props -->
-              <use href="#tree" transform="translate(170,750) scale(0.7)" />
-              <g transform="translate(228,764)">
-                <rect x="-2" y="-34" width="4" height="34" fill="#8a5a33" />
-                <path d="M 2 -34 L 34 -26 L 2 -18 Z" fill="#4f78d9" />
+              <!-- Risky Reels drive-in island -->
+              <use href="#tree" transform="translate(160,745) scale(0.7)" />
+              <g transform="translate(215,760)" filter="url(#dropSh)">
+                <rect x="-4" y="-4" width="4" height="18" fill="#8a5a33" />
+                <rect x="28" y="-4" width="4" height="18" fill="#8a5a33" />
+                <rect x="-8" y="-34" width="44" height="32" fill="#f2f6fa" stroke="#39435a" stroke-width="3" />
+                <rect x="6" y="20" width="7" height="5" fill="#d94f4f" />
+                <rect x="18" y="22" width="7" height="5" fill="#4f78d9" />
               </g>
             </g>
           </defs>
 
-          <!-- visible map -->
           <use href="#islandArt" />
 
-          <!-- storm circle -->
           <g class="storm">
-            <circle id="stormCircle" cx="800" cy="500" r="620" fill="none" stroke="url(#stormGrad)" stroke-width="10" opacity="0.85" />
+            <circle id="stormCircle" cx="800" cy="500" r="620" class="storm-line" />
           </g>
 
-          <!-- ============ CLICKABLE POI HOTSPOTS ============ -->
           <g id="poiLayer">
-            <g class="poi" data-poi="education" tabindex="0" role="button" aria-label="Boulder Bluffs: Education">
+            <g class="poi" data-poi="education" tabindex="0" role="button" aria-label="Polar Peak: Education">
               <circle cx="345" cy="395" r="95" class="poi-hit" />
-              <text x="345" y="475" class="poi-label">BOULDER BLUFFS</text>
+              <text x="345" y="475" class="poi-label">POLAR PEAK</text>
               <text x="345" y="497" class="poi-tag">EDUCATION</text>
             </g>
-            <g class="poi" data-poi="projects" tabindex="0" role="button" aria-label="Pleasant Projects: Projects">
+            <g class="poi" data-poi="projects" tabindex="0" role="button" aria-label="Pleasant Park: Projects">
               <circle cx="630" cy="245" r="85" class="poi-hit" />
-              <text x="630" y="330" class="poi-label">PLEASANT PROJECTS</text>
+              <text x="630" y="330" class="poi-label">PLEASANT PARK</text>
               <text x="630" y="352" class="poi-tag">PROJECTS</text>
             </g>
-            <g class="poi" data-poi="experience" tabindex="0" role="button" aria-label="Tilted Tech Towers: Experience">
+            <g class="poi" data-poi="experience" tabindex="0" role="button" aria-label="Tilted Towers: Experience">
               <circle cx="800" cy="470" r="100" class="poi-hit" />
-              <text x="800" y="580" class="poi-label">TILTED TECH TOWERS</text>
+              <text x="800" y="580" class="poi-label">TILTED TOWERS</text>
               <text x="800" y="602" class="poi-tag">EXPERIENCE</text>
             </g>
-            <g class="poi" data-poi="contact" tabindex="0" role="button" aria-label="Loot Lake Links: Contact">
+            <g class="poi" data-poi="contact" tabindex="0" role="button" aria-label="Loot Lake: Contact">
               <circle cx="1080" cy="425" r="90" class="poi-hit" />
-              <text x="1080" y="530" class="poi-label">LOOT LAKE LINKS</text>
+              <text x="1080" y="530" class="poi-label">LOOT LAKE</text>
               <text x="1080" y="552" class="poi-tag">CONTACT</text>
             </g>
-            <g class="poi" data-poi="skills" tabindex="0" role="button" aria-label="Salty Skills Springs: Skills">
+            <g class="poi" data-poi="skills" tabindex="0" role="button" aria-label="Salty Springs: Skills">
               <circle cx="905" cy="745" r="90" class="poi-hit" />
-              <text x="905" y="840" class="poi-label">SALTY SKILLS SPRINGS</text>
+              <text x="905" y="840" class="poi-label">SALTY SPRINGS</text>
               <text x="905" y="862" class="poi-tag">SKILLS</text>
             </g>
-            <g class="poi" data-poi="about" tabindex="0" role="button" aria-label="Spawn Island: About Ali">
+            <g class="poi" data-poi="about" tabindex="0" role="button" aria-label="Risky Reels: About Ali">
               <circle cx="200" cy="770" r="90" class="poi-hit" />
-              <text x="200" y="880" class="poi-label">SPAWN ISLAND</text>
+              <text x="200" y="880" class="poi-label">RISKY REELS</text>
               <text x="200" y="902" class="poi-tag">ABOUT ME</text>
             </g>
           </g>
 
-          <!-- battle bus -->
-          <g id="battleBus" class="battle-bus" aria-hidden="true">
-            <path d="M 0 -46 Q -34 -78 0 -92 Q 34 -78 0 -46 Z" fill="#7b2ff7" stroke="#5a1fd0" stroke-width="3" />
-            <line x1="-14" y1="-52" x2="-10" y2="-24" stroke="#333" stroke-width="2.5" />
-            <line x1="14" y1="-52" x2="10" y2="-24" stroke="#333" stroke-width="2.5" />
-            <rect x="-38" y="-24" width="76" height="34" rx="8" fill="#4f78d9" stroke="#2d4fa3" stroke-width="3" />
-            <rect x="-30" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
-            <rect x="-9" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
-            <rect x="12" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
-            <circle cx="-22" cy="12" r="7" fill="#222" /><circle cx="22" cy="12" r="7" fill="#222" />
-          </g>
+          <use id="busFallback" href="#busShape" width="90" height="120" x="-45" y="-100" opacity="0" />
         </svg>
       </div>
+
+      <!-- Epic fan-content attribution (required for fan projects using Epic assets) -->
+      <p class="fan-note">
+        Fan-made portfolio. Portions of the materials used are trademarks and/or copyrighted works of Epic Games, Inc.
+        All rights reserved by Epic. This material is not official and is not endorsed by Epic.
+        Map imagery via <a href="https://github.com/yaelbrinkert/fortnite-archives" target="_blank" rel="noreferrer">fortnite-archives</a>.
+      </p>
 
       <!-- Victory banner -->
       <div id="victory" class="victory" hidden>
         <div class="victory-inner">
           <p class="victory-hash">#1</p>
           <p class="victory-title">VICTORY ROYALE</p>
-          <p class="victory-sub">You discovered every POI. Time to recruit Ali.</p>
-          <a class="panel-btn gold" href="mailto:ali.haroon@colorado.edu">SEND THE INVITE ✉️</a>
+          <p class="victory-sub">You cleared every POI. Time to recruit Ali.</p>
+          <a class="panel-btn gold" href="mailto:ali.haroon@colorado.edu">SEND THE INVITE</a>
           <button class="victory-close" id="victoryClose">Keep exploring</button>
         </div>
       </div>
@@ -288,10 +358,10 @@
     <section class="panel" data-panel="experience" hidden aria-label="Experience">
       <header class="panel-head">
         <div>
-          <h2>TILTED TECH TOWERS</h2>
+          <h2>TILTED TOWERS</h2>
           <p>QUESTLINE: WORK EXPERIENCE</p>
         </div>
-        <button class="panel-close" aria-label="Close">✕</button>
+        <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body">
         <article class="quest legendary">
@@ -301,10 +371,10 @@
           </div>
           <p class="quest-meta">Westminster, CO &bull; Jun 2025 – Aug 2025</p>
           <ul class="quest-list">
-            <li><span class="check">✔</span> Engineered distributed infrastructure for 6 satellite ground-station monitoring environments with Java + Kubernetes <b class="xp">−30% incident response time</b></li>
-            <li><span class="check">✔</span> Built observability dashboards with Grafana, Prometheus, and Java collectors <b class="xp">35 production services</b></li>
-            <li><span class="check">✔</span> Designed automated testing workflows for 15+ Linux microservices with Jenkins CI/CD <b class="xp">+10,000 XP</b></li>
-            <li><span class="check">✔</span> Implemented Spring Boot APIs for low-latency inference <b class="xp">1K+ req/min</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Engineered distributed infrastructure for 6 satellite ground-station monitoring environments with Java + Kubernetes <b class="xp">−30% incident response time</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Built observability dashboards with Grafana, Prometheus, and Java collectors <b class="xp">35 production services</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Designed automated testing workflows for 15+ Linux microservices with Jenkins CI/CD <b class="xp">+10,000 XP</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Implemented Spring Boot APIs for low-latency inference <b class="xp">1K+ req/min</b></li>
           </ul>
         </article>
 
@@ -315,9 +385,9 @@
           </div>
           <p class="quest-meta">Boulder, CO &bull; Jul 2025 – Present</p>
           <ul class="quest-list">
-            <li><span class="check">✔</span> Developed full-stack Django apps with PostgreSQL on GCP <b class="xp">50K+ research records</b></li>
-            <li><span class="check">✔</span> Built automated pipelines with Python, pandas, and the REDCap API for large-scale cleaning + transformation <b class="xp">+8,000 XP</b></li>
-            <li><span class="check">✔</span> Designed migration &amp; reporting workflows <b class="xp">+300% processing speed</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Developed full-stack Django apps with PostgreSQL on GCP <b class="xp">50K+ research records</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Built automated pipelines with Python, pandas, and the REDCap API for large-scale cleaning + transformation <b class="xp">+8,000 XP</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Designed migration &amp; reporting workflows <b class="xp">+300% processing speed</b></li>
           </ul>
         </article>
 
@@ -328,9 +398,9 @@
           </div>
           <p class="quest-meta">Greenwood Village, CO &bull; May 2024 – Jul 2024</p>
           <ul class="quest-list">
-            <li><span class="check">✔</span> Built a BI platform with C#, ASP.NET Core, and React <b class="xp">125+ client systems</b></li>
-            <li><span class="check">✔</span> Optimized a SQL Server analytics stack with Entity Framework <b class="xp">500+ daily queries</b></li>
-            <li><span class="check">✔</span> Implemented Azure DevOps + Docker CI/CD in Agile/SCRUM workflows <b class="xp">+6,000 XP</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Built a BI platform with C#, ASP.NET Core, and React <b class="xp">125+ client systems</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Optimized a SQL Server analytics stack with Entity Framework <b class="xp">500+ daily queries</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Implemented Azure DevOps + Docker CI/CD in Agile/SCRUM workflows <b class="xp">+6,000 XP</b></li>
           </ul>
         </article>
       </div>
@@ -339,10 +409,10 @@
     <section class="panel" data-panel="projects" hidden aria-label="Projects">
       <header class="panel-head">
         <div>
-          <h2>PLEASANT PROJECTS</h2>
+          <h2>PLEASANT PARK</h2>
           <p>LOOT DROPS: THINGS I BUILT</p>
         </div>
-        <button class="panel-close" aria-label="Close">✕</button>
+        <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body loot-grid">
         <article class="loot legendary">
@@ -350,21 +420,21 @@
           <h3>Polymarket Weather Prediction</h3>
           <p>Prediction-market weather model trading on real Polymarket data.</p>
           <p class="loot-stack">Rust &bull; Python &bull; NumPy &bull; pandas &bull; Scikit-learn &bull; PostgreSQL</p>
-          <a class="panel-btn" href="https://github.com/Ali-Haroon3/Polymarket-Weather-Predictor" target="_blank" rel="noreferrer">INSPECT ON GITHUB ↗</a>
+          <a class="panel-btn" href="https://github.com/Ali-Haroon3/Polymarket-Weather-Predictor" target="_blank" rel="noreferrer">INSPECT ON GITHUB <svg class="ico"><use href="#i-out" /></svg></a>
         </article>
         <article class="loot epic">
           <span class="rarity-pill">EPIC</span>
           <h3>BlackjackTrainer</h3>
           <p>AI-assisted blackjack strategy trainer, deployed on AWS.</p>
           <p class="loot-stack">Python &bull; Flask &bull; JavaScript &bull; AWS</p>
-          <a class="panel-btn" href="https://github.com/Ali-Haroon3/AIBlackJackTrainer" target="_blank" rel="noreferrer">INSPECT ON GITHUB ↗</a>
+          <a class="panel-btn" href="https://github.com/Ali-Haroon3/AIBlackJackTrainer" target="_blank" rel="noreferrer">INSPECT ON GITHUB <svg class="ico"><use href="#i-out" /></svg></a>
         </article>
         <article class="loot epic">
           <span class="rarity-pill">EPIC</span>
           <h3>Lung Cancer Detection</h3>
           <p>Deep-learning imaging classifier with an interactive Streamlit front end.</p>
           <p class="loot-stack">Python &bull; TensorFlow &bull; Streamlit &bull; PostgreSQL</p>
-          <a class="panel-btn" href="https://github.com/Ali-Haroon3/Lung-Cancer-Detection" target="_blank" rel="noreferrer">INSPECT ON GITHUB ↗</a>
+          <a class="panel-btn" href="https://github.com/Ali-Haroon3/Lung-Cancer-Detection" target="_blank" rel="noreferrer">INSPECT ON GITHUB <svg class="ico"><use href="#i-out" /></svg></a>
         </article>
       </div>
     </section>
@@ -372,10 +442,10 @@
     <section class="panel" data-panel="skills" hidden aria-label="Skills">
       <header class="panel-head">
         <div>
-          <h2>SALTY SKILLS SPRINGS</h2>
+          <h2>SALTY SPRINGS</h2>
           <p>LOCKER: EQUIPPED SKILLS</p>
         </div>
-        <button class="panel-close" aria-label="Close">✕</button>
+        <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body">
         <div class="inv-grid">
@@ -404,10 +474,10 @@
     <section class="panel" data-panel="education" hidden aria-label="Education">
       <header class="panel-head">
         <div>
-          <h2>BOULDER BLUFFS</h2>
+          <h2>POLAR PEAK</h2>
           <p>TRAINING GROUNDS: EDUCATION</p>
         </div>
-        <button class="panel-close" aria-label="Close">✕</button>
+        <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body">
         <article class="quest legendary">
@@ -415,11 +485,11 @@
             <h3>University of Colorado Boulder</h3>
             <span class="rarity-pill">SENIOR &bull; LEVEL 4/4</span>
           </div>
-          <p class="quest-meta">Boulder, CO &bull; the real Boulder Bluffs</p>
+          <p class="quest-meta">Boulder, CO &bull; the Flatirons are basically Polar Peak</p>
           <ul class="quest-list">
-            <li><span class="check">✔</span> B.S. Computer Science <b class="xp">MAIN CLASS</b></li>
-            <li><span class="check">✔</span> Mathematics <b class="xp">DUAL WIELD</b></li>
-            <li><span class="check">✔</span> Biochemistry <b class="xp">THIRD SLOT</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> B.S. Computer Science <b class="xp">MAIN CLASS</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Mathematics <b class="xp">DUAL WIELD</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Biochemistry <b class="xp">THIRD SLOT</b></li>
           </ul>
           <div class="xp-bar"><div class="xp-fill"></div><span>SEASON PROGRESS: SENIOR YEAR</span></div>
         </article>
@@ -429,10 +499,10 @@
     <section class="panel" data-panel="contact" hidden aria-label="Contact">
       <header class="panel-head">
         <div>
-          <h2>LOOT LAKE LINKS</h2>
+          <h2>LOOT LAKE</h2>
           <p>OPEN THE CHEST: CONTACT ALI</p>
         </div>
-        <button class="panel-close" aria-label="Close">✕</button>
+        <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body">
         <div id="chestZone" class="chest-zone">
@@ -440,14 +510,14 @@
             <svg viewBox="0 0 120 90" width="150" height="112">
               <rect x="12" y="34" width="96" height="48" rx="6" fill="#a8642c" stroke="#6f3f16" stroke-width="4" />
               <path class="chest-lid" d="M 12 36 Q 60 -8 108 36 Z" fill="#c07a38" stroke="#6f3f16" stroke-width="4" />
-              <rect x="52" y="40" width="16" height="26" rx="3" fill="#ffd54d" stroke="#b8860b" stroke-width="3" />
+              <rect x="52" y="40" width="16" height="26" rx="3" fill="#ffd21f" stroke="#b8860b" stroke-width="3" />
             </svg>
             <span>TAP TO OPEN</span>
           </button>
           <div class="chest-loot" hidden>
-            <a class="panel-btn gold" href="mailto:ali.haroon@colorado.edu">✉️ ali.haroon@colorado.edu</a>
-            <a class="panel-btn" href="https://github.com/Ali-Haroon3" target="_blank" rel="noreferrer">🐙 github.com/Ali-Haroon3</a>
-            <a class="panel-btn" href="https://www.ali-haroon.com" target="_blank" rel="noreferrer">🌐 ali-haroon.com</a>
+            <a class="panel-btn gold" href="mailto:ali.haroon@colorado.edu"><svg class="ico"><use href="#i-mail" /></svg> ali.haroon@colorado.edu</a>
+            <a class="panel-btn" href="https://github.com/Ali-Haroon3" target="_blank" rel="noreferrer"><svg class="ico"><use href="#i-code" /></svg> github.com/Ali-Haroon3</a>
+            <a class="panel-btn" href="https://www.ali-haroon.com" target="_blank" rel="noreferrer"><svg class="ico"><use href="#i-globe" /></svg> ali-haroon.com</a>
             <p class="chest-note">US Citizen &bull; open to 2026 opportunities</p>
           </div>
         </div>
@@ -457,10 +527,10 @@
     <section class="panel" data-panel="about" hidden aria-label="About Ali">
       <header class="panel-head">
         <div>
-          <h2>SPAWN ISLAND</h2>
-          <p>CHARACTER SELECT: WHO IS ALI?</p>
+          <h2>RISKY REELS</h2>
+          <p>NOW SHOWING: WHO IS ALI?</p>
         </div>
-        <button class="panel-close" aria-label="Close">✕</button>
+        <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body">
         <div class="about-card">

--- a/fortnite/index.html
+++ b/fortnite/index.html
@@ -52,9 +52,12 @@
         <symbol id="i-x" viewBox="0 0 24 24">
           <path d="M 6 6 L 18 18 M 18 6 L 6 18" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" />
         </symbol>
+        <symbol id="i-play" viewBox="0 0 24 24">
+          <path d="M 7 4.5 L 19.5 12 L 7 19.5 Z" fill="currentColor" />
+        </symbol>
         <!-- battle bus, shared by both map modes -->
         <symbol id="busShape" viewBox="-45 -100 90 120">
-          <path d="M 0 -46 Q -34 -78 0 -92 Q 34 -78 0 -46 Z" fill="#8547e8" stroke="#5a1fd0" stroke-width="3" />
+          <path d="M 0 -46 Q -34 -78 0 -92 Q 34 -78 0 -46 Z" fill="#b04df9" stroke="#7a2fc4" stroke-width="3" />
           <line x1="-14" y1="-52" x2="-10" y2="-24" stroke="#2a2a2a" stroke-width="2.5" />
           <line x1="14" y1="-52" x2="10" y2="-24" stroke="#2a2a2a" stroke-width="2.5" />
           <rect x="-38" y="-24" width="76" height="34" rx="8" fill="#4f78d9" stroke="#2d4fa3" stroke-width="3" />
@@ -69,11 +72,14 @@
 
     <!-- ============ LOBBY / LOADING SCREEN ============ -->
     <div id="lobby" class="lobby">
-      <div class="lobby-sky"></div>
+      <div class="lobby-sky">
+        <div class="slash slash-1"></div>
+        <div class="slash slash-2"></div>
+      </div>
       <div class="lobby-content">
-        <p class="lobby-eyebrow">SEASON 2026 &bull; CHAPTER: SENIOR YEAR</p>
+        <p class="lobby-eyebrow">SEASON 2026 &bull; CHAPTER 2: POST-GRAD</p>
         <h1 class="lobby-title">ALI<br />HAROON</h1>
-        <p class="lobby-sub">SOFTWARE ENGINEER &bull; CU BOULDER &bull; CS + MATH + BIOCHEM</p>
+        <p class="lobby-sub">SOFTWARE ENGINEER @ VISA &bull; CO-FOUNDER @ CRONYS &bull; CU BOULDER GRAD</p>
         <button id="playBtn" class="play-btn">
           <span>DROP IN</span>
         </button>
@@ -125,43 +131,52 @@
         <a class="slot" href="../index.html" title="Classic portfolio"><svg class="ico"><use href="#i-pad" /></svg><em>Classic</em></a>
       </div>
 
-      <!-- ============ REAL MAP MODE (Season 7 island via fortnite-archives) ============ -->
+      <!-- ============ REAL MAP MODE (Fortnite Reload island via fortnite-archives) ============ -->
       <div id="realStage" class="real-stage" hidden>
         <div class="map-box">
-          <img id="mapImg" alt="Fortnite Chapter 1 Season 7 island map" draggable="false" />
+          <img id="mapImg" alt="Fortnite Reload island map" draggable="false" />
           <svg class="map-overlay" viewBox="0 0 4096 4096" preserveAspectRatio="none" aria-hidden="true">
+            <!-- in-game style grid -->
+            <g class="map-grid">
+              <path d="M 409.6 0 V 4096 M 819.2 0 V 4096 M 1228.8 0 V 4096 M 1638.4 0 V 4096 M 2048 0 V 4096 M 2457.6 0 V 4096 M 2867.2 0 V 4096 M 3276.8 0 V 4096 M 3686.4 0 V 4096
+                       M 0 409.6 H 4096 M 0 819.2 H 4096 M 0 1228.8 H 4096 M 0 1638.4 H 4096 M 0 2048 H 4096 M 0 2457.6 H 4096 M 0 2867.2 H 4096 M 0 3276.8 H 4096 M 0 3686.4 H 4096" />
+              <g class="map-grid-text">
+                <text x="204.8" y="90">A</text><text x="614.4" y="90">B</text><text x="1024" y="90">C</text><text x="1433.6" y="90">D</text><text x="1843.2" y="90">E</text><text x="2252.8" y="90">F</text><text x="2662.4" y="90">G</text><text x="3072" y="90">H</text><text x="3481.6" y="90">I</text><text x="3891.2" y="90">J</text>
+                <text x="55" y="235">1</text><text x="55" y="645">2</text><text x="55" y="1055">3</text><text x="55" y="1464">4</text><text x="55" y="1874">5</text><text x="55" y="2283">6</text><text x="55" y="2693">7</text><text x="55" y="3103">8</text><text x="55" y="3512">9</text><text x="55" y="3922">10</text>
+              </g>
+            </g>
             <circle id="stormReal" cx="2048" cy="2048" r="2400" class="storm-line" />
             <use id="busReal" href="#busShape" width="240" height="320" x="-120" y="-260" opacity="0" />
           </svg>
-          <!-- hotspots: positions read off the 4096px map -->
-          <button class="spot" data-poi="experience" style="--x:37.5%; --y:48%">
+          <!-- hotspots: positions read off the Reload map -->
+          <button class="spot" data-poi="experience" style="--x:54.5%; --y:57%">
             <span class="spot-ring"></span>
             <span class="spot-name">TILTED TOWERS</span>
             <span class="spot-tag">EXPERIENCE</span>
           </button>
-          <button class="spot" data-poi="projects" style="--x:26.5%; --y:29%">
+          <button class="spot" data-poi="projects" style="--x:30%; --y:45.5%">
             <span class="spot-ring"></span>
             <span class="spot-name">PLEASANT PARK</span>
             <span class="spot-tag">PROJECTS</span>
           </button>
-          <button class="spot" data-poi="skills" style="--x:52.5%; --y:61%">
+          <button class="spot" data-poi="skills" style="--x:79%; --y:73.5%">
             <span class="spot-ring"></span>
-            <span class="spot-name">SALTY SPRINGS</span>
+            <span class="spot-name">RETAIL ROW</span>
             <span class="spot-tag">SKILLS</span>
           </button>
-          <button class="spot" data-poi="contact" style="--x:43%; --y:37%">
+          <button class="spot" data-poi="contact" style="--x:39%; --y:61.5%">
             <span class="spot-ring"></span>
-            <span class="spot-name">LOOT LAKE</span>
+            <span class="spot-name">LIL' LOOT LAKE</span>
             <span class="spot-tag">CONTACT</span>
           </button>
-          <button class="spot" data-poi="education" style="--x:14%; --y:52.8%">
+          <button class="spot" data-poi="education" style="--x:72.5%; --y:42.5%">
             <span class="spot-ring"></span>
-            <span class="spot-name">POLAR PEAK</span>
+            <span class="spot-name">SNOBBY SHOALS</span>
             <span class="spot-tag">EDUCATION</span>
           </button>
-          <button class="spot" data-poi="about" style="--x:71%; --y:19%">
+          <button class="spot" data-poi="about" style="--x:50%; --y:31.5%">
             <span class="spot-ring"></span>
-            <span class="spot-name">RISKY REELS</span>
+            <span class="spot-name">LONE LODGE</span>
             <span class="spot-tag">ABOUT ME</span>
           </button>
         </div>
@@ -183,7 +198,7 @@
             </g>
 
             <g id="islandArt">
-              <rect x="0" y="0" width="1600" height="1000" fill="#1f7ac9" />
+              <rect x="0" y="0" width="1600" height="1000" fill="#103a8c" />
               <circle cx="800" cy="500" r="560" fill="none" stroke="#ffffff" stroke-opacity="0.08" stroke-width="18" />
               <circle cx="800" cy="500" r="640" fill="none" stroke="#ffffff" stroke-opacity="0.05" stroke-width="14" />
 
@@ -202,10 +217,10 @@
                        C 1128 800, 962 866, 800 848
                        C 634 830, 500 790, 424 672
                        C 350 552, 368 428, 410 320 Z"
-                    fill="#79b74f" />
+                    fill="#318218" />
 
               <ellipse cx="200" cy="775" rx="105" ry="72" fill="#e8d29a" />
-              <ellipse cx="200" cy="770" rx="88" ry="58" fill="#79b74f" />
+              <ellipse cx="200" cy="770" rx="88" ry="58" fill="#318218" />
 
               <path d="M 1000 350 C 1060 320, 1160 330, 1190 390 C 1220 450, 1180 510, 1110 520 C 1035 530, 970 490, 965 435 C 962 395, 965 370, 1000 350 Z"
                     fill="#2e9fd9" stroke="#e8d29a" stroke-width="8" />
@@ -221,7 +236,7 @@
                 <path d="M 360 400 C 460 430, 640 480, 780 510" />
               </g>
 
-              <!-- Polar Peak mountains -->
+              <!-- Snobby Shoals cliffs -->
               <g transform="translate(330,370)">
                 <path d="M -80 60 L -10 -70 L 55 60 Z" fill="#9aa7b8" />
                 <path d="M -10 -70 L -34 -20 L 14 -20 Z" fill="#f2f6fa" />
@@ -244,7 +259,7 @@
                 <rect x="-58" y="-70" width="34" height="88" fill="#9fb0c4" transform="rotate(-4 -41 -26)" />
                 <rect x="-14" y="-98" width="40" height="116" fill="#9fb0c4" />
                 <rect x="34" y="-58" width="30" height="76" fill="#9fb0c4" transform="rotate(4 49 -20)" />
-                <g fill="#ffd21f">
+                <g fill="#fbd444">
                   <rect x="-8" y="-88" width="8" height="8" /><rect x="8" y="-88" width="8" height="8" />
                   <rect x="-8" y="-68" width="8" height="8" /><rect x="8" y="-48" width="8" height="8" />
                   <rect x="-52" y="-58" width="7" height="7" /><rect x="-40" y="-38" width="7" height="7" />
@@ -252,21 +267,21 @@
                 </g>
               </g>
 
-              <!-- Salty Springs -->
-              <g transform="translate(905,755)">
-                <ellipse cx="-30" cy="10" rx="26" ry="14" fill="#57c7e8" stroke="#e8d29a" stroke-width="5" />
-                <ellipse cx="34" cy="-4" rx="20" ry="11" fill="#57c7e8" stroke="#e8d29a" stroke-width="5" />
-                <g filter="url(#dropSh)">
-                  <rect x="-8" y="-38" width="38" height="26" fill="#f3e3c6" />
-                  <path d="M -13 -38 L 11 -56 L 35 -38 Z" fill="#d98a3f" />
-                </g>
+              <!-- Retail Row shops -->
+              <g transform="translate(905,755)" filter="url(#dropSh)">
+                <rect x="-52" y="-20" width="40" height="30" fill="#d94f4f" />
+                <rect x="-52" y="-28" width="40" height="8" fill="#f2f6fa" />
+                <rect x="-4" y="-38" width="38" height="26" fill="#f3e3c6" />
+                <path d="M -9 -38 L 15 -56 L 39 -38 Z" fill="#d98a3f" />
+                <rect x="-4" y="-6" width="38" height="16" fill="#4f78d9" />
+                <rect x="-4" y="-12" width="38" height="6" fill="#f2f6fa" />
               </g>
 
-              <!-- Loot Lake chest island -->
+              <!-- Lil' Loot Lake chest island -->
               <g transform="translate(1080,420)" filter="url(#dropSh)">
                 <rect x="-16" y="-10" width="32" height="20" rx="3" fill="#a8642c" />
                 <path d="M -16 -10 Q 0 -26 16 -10 Z" fill="#c07a38" />
-                <rect x="-3" y="-8" width="6" height="16" fill="#ffd21f" />
+                <rect x="-3" y="-8" width="6" height="16" fill="#fbd444" />
               </g>
 
               <use href="#tree" transform="translate(520,560)" />
@@ -278,14 +293,14 @@
               <use href="#tree" transform="translate(450,520) scale(0.75)" />
               <use href="#tree" transform="translate(1100,700) scale(0.8)" />
 
-              <!-- Risky Reels drive-in island -->
+              <!-- Lone Lodge island -->
               <use href="#tree" transform="translate(160,745) scale(0.7)" />
-              <g transform="translate(215,760)" filter="url(#dropSh)">
-                <rect x="-4" y="-4" width="4" height="18" fill="#8a5a33" />
-                <rect x="28" y="-4" width="4" height="18" fill="#8a5a33" />
-                <rect x="-8" y="-34" width="44" height="32" fill="#f2f6fa" stroke="#39435a" stroke-width="3" />
-                <rect x="6" y="20" width="7" height="5" fill="#d94f4f" />
-                <rect x="18" y="22" width="7" height="5" fill="#4f78d9" />
+              <use href="#tree" transform="translate(250,795) scale(0.6)" />
+              <g transform="translate(200,775)" filter="url(#dropSh)">
+                <rect x="-26" y="-22" width="52" height="30" fill="#8a5a33" />
+                <path d="M -32 -22 L 0 -46 L 32 -22 Z" fill="#6f4222" />
+                <rect x="14" y="-40" width="8" height="14" fill="#5c3618" />
+                <rect x="-8" y="-8" width="16" height="16" fill="#3c2410" />
               </g>
             </g>
           </defs>
@@ -297,9 +312,9 @@
           </g>
 
           <g id="poiLayer">
-            <g class="poi" data-poi="education" tabindex="0" role="button" aria-label="Polar Peak: Education">
+            <g class="poi" data-poi="education" tabindex="0" role="button" aria-label="Snobby Shoals: Education">
               <circle cx="345" cy="395" r="95" class="poi-hit" />
-              <text x="345" y="475" class="poi-label">POLAR PEAK</text>
+              <text x="345" y="475" class="poi-label">SNOBBY SHOALS</text>
               <text x="345" y="497" class="poi-tag">EDUCATION</text>
             </g>
             <g class="poi" data-poi="projects" tabindex="0" role="button" aria-label="Pleasant Park: Projects">
@@ -312,19 +327,19 @@
               <text x="800" y="580" class="poi-label">TILTED TOWERS</text>
               <text x="800" y="602" class="poi-tag">EXPERIENCE</text>
             </g>
-            <g class="poi" data-poi="contact" tabindex="0" role="button" aria-label="Loot Lake: Contact">
+            <g class="poi" data-poi="contact" tabindex="0" role="button" aria-label="Lil' Loot Lake: Contact">
               <circle cx="1080" cy="425" r="90" class="poi-hit" />
-              <text x="1080" y="530" class="poi-label">LOOT LAKE</text>
+              <text x="1080" y="530" class="poi-label">LIL' LOOT LAKE</text>
               <text x="1080" y="552" class="poi-tag">CONTACT</text>
             </g>
-            <g class="poi" data-poi="skills" tabindex="0" role="button" aria-label="Salty Springs: Skills">
+            <g class="poi" data-poi="skills" tabindex="0" role="button" aria-label="Retail Row: Skills">
               <circle cx="905" cy="745" r="90" class="poi-hit" />
-              <text x="905" y="840" class="poi-label">SALTY SPRINGS</text>
+              <text x="905" y="840" class="poi-label">RETAIL ROW</text>
               <text x="905" y="862" class="poi-tag">SKILLS</text>
             </g>
-            <g class="poi" data-poi="about" tabindex="0" role="button" aria-label="Risky Reels: About Ali">
+            <g class="poi" data-poi="about" tabindex="0" role="button" aria-label="Lone Lodge: About Ali">
               <circle cx="200" cy="770" r="90" class="poi-hit" />
-              <text x="200" y="880" class="poi-label">RISKY REELS</text>
+              <text x="200" y="880" class="poi-label">LONE LODGE</text>
               <text x="200" y="902" class="poi-tag">ABOUT ME</text>
             </g>
           </g>
@@ -364,43 +379,64 @@
         <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body">
+        <article class="quest mythic">
+          <div class="quest-top">
+            <h3>Visa — Software Engineer</h3>
+            <span class="rarity-pill">MYTHIC QUEST &bull; ACTIVE</span>
+          </div>
+          <p class="quest-meta">Highlands Ranch, CO &bull; Jun 2026 – Present</p>
+          <ul class="quest-list">
+            <li><svg class="ico check"><use href="#i-check" /></svg> Designed and enhanced Spring Boot RESTful APIs serving a real-time transaction-monitoring platform <b class="xp">LIVE FINANCIAL DATA STREAMS</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Maintained data integrity across IBM DB2 databases backing production analytics <b class="xp">MISSION-CRITICAL</b></li>
+          </ul>
+        </article>
+
         <article class="quest legendary">
           <div class="quest-top">
-            <h3>Vantor — Software Development Intern</h3>
-            <span class="rarity-pill">LEGENDARY QUEST</span>
+            <h3>Cronys — Co-Founder</h3>
+            <span class="rarity-pill">LEGENDARY QUEST &bull; ACTIVE</span>
           </div>
-          <p class="quest-meta">Westminster, CO &bull; Jun 2025 – Aug 2025</p>
+          <p class="quest-meta">Remote (cronys.xyz) &bull; Mar 2026 – Present</p>
           <ul class="quest-list">
-            <li><svg class="ico check"><use href="#i-check" /></svg> Engineered distributed infrastructure for 6 satellite ground-station monitoring environments with Java + Kubernetes <b class="xp">−30% incident response time</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Built observability dashboards with Grafana, Prometheus, and Java collectors <b class="xp">35 production services</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Designed automated testing workflows for 15+ Linux microservices with Jenkins CI/CD <b class="xp">+10,000 XP</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Implemented Spring Boot APIs for low-latency inference <b class="xp">1K+ req/min</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Co-founded an AI agent governance platform — FastAPI backend with RAG-based retrieval — evaluating and classifying agent actions in real time <b class="xp">$25K PRE-SEED</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Designed the policy engine and evaluation infrastructure for automated governance decisions <b class="xp">BUILT FOR AUDIT + SCALE</b></li>
           </ul>
         </article>
 
         <article class="quest epic">
           <div class="quest-top">
-            <h3>CUChange — Data Management Research Assistant</h3>
-            <span class="rarity-pill">EPIC QUEST &bull; ACTIVE</span>
+            <h3>Vantor (formerly Maxar) — Software Development Intern</h3>
+            <span class="rarity-pill">EPIC QUEST</span>
           </div>
-          <p class="quest-meta">Boulder, CO &bull; Jul 2025 – Present</p>
+          <p class="quest-meta">Westminster, CO &bull; Jun 2025 – Aug 2025</p>
           <ul class="quest-list">
-            <li><svg class="ico check"><use href="#i-check" /></svg> Developed full-stack Django apps with PostgreSQL on GCP <b class="xp">50K+ research records</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Built automated pipelines with Python, pandas, and the REDCap API for large-scale cleaning + transformation <b class="xp">+8,000 XP</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Designed migration &amp; reporting workflows <b class="xp">+300% processing speed</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Engineered distributed monitoring across 6 satellite ground stations with real-time telemetry ingestion <b class="xp">SUB-SECOND LATENCY</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Implemented Spring Boot REST APIs for low-latency data access and inference <b class="xp">1K+ REQ/MIN</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Built the observability stack (Grafana, Prometheus, Java collectors) and automated QA for 15+ Linux microservices with Jenkins <b class="xp">35 SERVICES</b></li>
           </ul>
         </article>
 
         <article class="quest rare">
           <div class="quest-top">
-            <h3>ReportsNow — Software Engineering Intern</h3>
+            <h3>CUChange — Data Management Research Assistant</h3>
             <span class="rarity-pill">RARE QUEST</span>
+          </div>
+          <p class="quest-meta">Boulder, CO &bull; Jul 2025 – May 2026</p>
+          <ul class="quest-list">
+            <li><svg class="ico check"><use href="#i-check" /></svg> Built automated Python pipelines (pandas, SQL, REDCap API) ingesting and cleaning large-scale datasets <b class="xp">HETEROGENEOUS SOURCES</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Engineered reproducible Python/R workflows with PostgreSQL on GCP <b class="xp">+300% REPORT SPEED</b></li>
+          </ul>
+        </article>
+
+        <article class="quest uncommon">
+          <div class="quest-top">
+            <h3>ReportsNow — Software Engineering Intern</h3>
+            <span class="rarity-pill">UNCOMMON QUEST</span>
           </div>
           <p class="quest-meta">Greenwood Village, CO &bull; May 2024 – Jul 2024</p>
           <ul class="quest-list">
-            <li><svg class="ico check"><use href="#i-check" /></svg> Built a BI platform with C#, ASP.NET Core, and React <b class="xp">125+ client systems</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Optimized a SQL Server analytics stack with Entity Framework <b class="xp">500+ daily queries</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Implemented Azure DevOps + Docker CI/CD in Agile/SCRUM workflows <b class="xp">+6,000 XP</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Built a full-stack analytics app (C#, ASP.NET Core, React) consolidating data from 125+ client systems <b class="xp">−40% REPORT TIME</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Designed RESTful APIs with SQL Server; shipped via Azure DevOps CI/CD with Docker <b class="xp">500+ DAILY QUERIES</b></li>
           </ul>
         </article>
       </div>
@@ -418,21 +454,22 @@
         <article class="loot legendary">
           <span class="rarity-pill">LEGENDARY</span>
           <h3>Polymarket Weather Prediction</h3>
-          <p>Prediction-market weather model trading on real Polymarket data.</p>
-          <p class="loot-stack">Rust &bull; Python &bull; NumPy &bull; pandas &bull; Scikit-learn &bull; PostgreSQL</p>
+          <p>Rust + Python pipeline processing 500K+ NOAA records into PostgreSQL; calibrated probability forecasts (0.87 Brier) with Bayesian inference and Monte Carlo risk modeling for prediction-market contracts.</p>
+          <p class="loot-stack">Rust &bull; Python &bull; NumPy &bull; pandas &bull; PostgreSQL</p>
           <a class="panel-btn" href="https://github.com/Ali-Haroon3/Polymarket-Weather-Predictor" target="_blank" rel="noreferrer">INSPECT ON GITHUB <svg class="ico"><use href="#i-out" /></svg></a>
         </article>
         <article class="loot epic">
           <span class="rarity-pill">EPIC</span>
           <h3>BlackjackTrainer</h3>
-          <p>AI-assisted blackjack strategy trainer, deployed on AWS.</p>
+          <p>Production app on AWS App Runner with automated CI/CD; an RL / Monte Carlo tree search engine computes expected-value-optimal decisions.</p>
           <p class="loot-stack">Python &bull; Flask &bull; JavaScript &bull; AWS</p>
+          <a class="panel-btn gold" href="https://blackjacktrainings.com" target="_blank" rel="noreferrer"><svg class="ico"><use href="#i-play" /></svg> PLAY IT LIVE</a>
           <a class="panel-btn" href="https://github.com/Ali-Haroon3/AIBlackJackTrainer" target="_blank" rel="noreferrer">INSPECT ON GITHUB <svg class="ico"><use href="#i-out" /></svg></a>
         </article>
-        <article class="loot epic">
-          <span class="rarity-pill">EPIC</span>
-          <h3>Lung Cancer Detection</h3>
-          <p>Deep-learning imaging classifier with an interactive Streamlit front end.</p>
+        <article class="loot rare">
+          <span class="rarity-pill">RARE</span>
+          <h3>Lung Cancer Detection CNN</h3>
+          <p>Model inference app (ResNet50, DenseNet121) with a PostgreSQL backend for batch inference, audit logging, and model performance monitoring.</p>
           <p class="loot-stack">Python &bull; TensorFlow &bull; Streamlit &bull; PostgreSQL</p>
           <a class="panel-btn" href="https://github.com/Ali-Haroon3/Lung-Cancer-Detection" target="_blank" rel="noreferrer">INSPECT ON GITHUB <svg class="ico"><use href="#i-out" /></svg></a>
         </article>
@@ -442,39 +479,72 @@
     <section class="panel" data-panel="skills" hidden aria-label="Skills">
       <header class="panel-head">
         <div>
-          <h2>SALTY SPRINGS</h2>
-          <p>LOCKER: EQUIPPED SKILLS</p>
+          <h2>RETAIL ROW</h2>
+          <p>AISLES: THE FULL LOADOUT</p>
         </div>
         <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
       <div class="panel-body">
-        <div class="inv-grid">
-          <span class="inv legendary">Python</span>
-          <span class="inv legendary">Rust</span>
-          <span class="inv legendary">Java</span>
-          <span class="inv epic">C#</span>
-          <span class="inv epic">SQL</span>
-          <span class="inv epic">JavaScript</span>
-          <span class="inv epic">TensorFlow</span>
-          <span class="inv epic">PyTorch</span>
-          <span class="inv rare">Scikit-learn</span>
-          <span class="inv rare">Kubernetes</span>
-          <span class="inv rare">Docker</span>
-          <span class="inv rare">AWS</span>
-          <span class="inv uncommon">Jenkins</span>
-          <span class="inv uncommon">Azure DevOps</span>
-          <span class="inv uncommon">PostgreSQL</span>
-          <span class="inv common">Grafana</span>
-          <span class="inv common">Prometheus</span>
+        <div class="aisle">
+          <h3 class="aisle-name legendary-t">AISLE 1 &mdash; LANGUAGES</h3>
+          <div class="inv-grid">
+            <span class="inv legendary">Rust</span>
+            <span class="inv legendary">C++</span>
+            <span class="inv legendary">Java</span>
+            <span class="inv legendary">Python</span>
+            <span class="inv legendary">C#</span>
+            <span class="inv legendary">JavaScript</span>
+            <span class="inv legendary">SQL</span>
+          </div>
         </div>
-        <p class="inv-note">Rarity = how often it's in my main loadout, not how much I like it. Prometheus, you're still loved.</p>
+        <div class="aisle">
+          <h3 class="aisle-name epic-t">AISLE 2 &mdash; DISTRIBUTED SYSTEMS</h3>
+          <div class="inv-grid">
+            <span class="inv epic">High-Throughput APIs</span>
+            <span class="inv epic">Real-Time Streaming Pipelines</span>
+            <span class="inv epic">Observability (Grafana &bull; Prometheus)</span>
+            <span class="inv epic">Reliability Engineering</span>
+            <span class="inv epic">Horizontal Scaling</span>
+            <span class="inv epic">Load &amp; Rate Limiting</span>
+          </div>
+        </div>
+        <div class="aisle">
+          <h3 class="aisle-name rare-t">AISLE 3 &mdash; INFRASTRUCTURE</h3>
+          <div class="inv-grid">
+            <span class="inv rare">Docker</span>
+            <span class="inv rare">Kubernetes</span>
+            <span class="inv rare">AWS</span>
+            <span class="inv rare">GCP</span>
+            <span class="inv rare">Azure</span>
+            <span class="inv rare">Jenkins</span>
+            <span class="inv rare">CI/CD</span>
+            <span class="inv rare">Linux</span>
+            <span class="inv rare">PostgreSQL</span>
+            <span class="inv rare">SQL Server</span>
+            <span class="inv rare">IBM DB2</span>
+          </div>
+        </div>
+        <div class="aisle">
+          <h3 class="aisle-name uncommon-t">AISLE 4 &mdash; FRAMEWORKS &amp; ML</h3>
+          <div class="inv-grid">
+            <span class="inv uncommon">Spring Boot</span>
+            <span class="inv uncommon">FastAPI</span>
+            <span class="inv uncommon">Flask</span>
+            <span class="inv uncommon">React</span>
+            <span class="inv uncommon">RAG / Retrieval Systems</span>
+            <span class="inv uncommon">Agent Orchestration</span>
+            <span class="inv uncommon">TensorFlow</span>
+            <span class="inv uncommon">PyTorch</span>
+          </div>
+        </div>
+        <p class="inv-note">Aisle color = shelf category, not affection. Every item is kept in stock.</p>
       </div>
     </section>
 
     <section class="panel" data-panel="education" hidden aria-label="Education">
       <header class="panel-head">
         <div>
-          <h2>POLAR PEAK</h2>
+          <h2>SNOBBY SHOALS</h2>
           <p>TRAINING GROUNDS: EDUCATION</p>
         </div>
         <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
@@ -483,15 +553,16 @@
         <article class="quest legendary">
           <div class="quest-top">
             <h3>University of Colorado Boulder</h3>
-            <span class="rarity-pill">SENIOR &bull; LEVEL 4/4</span>
+            <span class="rarity-pill">GRADUATED &bull; MAY 2026</span>
           </div>
-          <p class="quest-meta">Boulder, CO &bull; the Flatirons are basically Polar Peak</p>
+          <p class="quest-meta">Boulder, CO &bull; where the tuition went</p>
           <ul class="quest-list">
             <li><svg class="ico check"><use href="#i-check" /></svg> B.S. Computer Science <b class="xp">MAIN CLASS</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Mathematics <b class="xp">DUAL WIELD</b></li>
-            <li><svg class="ico check"><use href="#i-check" /></svg> Biochemistry <b class="xp">THIRD SLOT</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Minor: Mathematics <b class="xp">DUAL WIELD</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> Minor: Biochemistry <b class="xp">THIRD SLOT</b></li>
+            <li><svg class="ico check"><use href="#i-check" /></svg> GPA 3.7 <b class="xp">RANKED</b></li>
           </ul>
-          <div class="xp-bar"><div class="xp-fill"></div><span>SEASON PROGRESS: SENIOR YEAR</span></div>
+          <div class="xp-bar"><div class="xp-fill" style="width:100%"></div><span>SEASON COMPLETE: CLASS OF 2026</span></div>
         </article>
       </div>
     </section>
@@ -499,7 +570,7 @@
     <section class="panel" data-panel="contact" hidden aria-label="Contact">
       <header class="panel-head">
         <div>
-          <h2>LOOT LAKE</h2>
+          <h2>LIL' LOOT LAKE</h2>
           <p>OPEN THE CHEST: CONTACT ALI</p>
         </div>
         <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
@@ -510,7 +581,7 @@
             <svg viewBox="0 0 120 90" width="150" height="112">
               <rect x="12" y="34" width="96" height="48" rx="6" fill="#a8642c" stroke="#6f3f16" stroke-width="4" />
               <path class="chest-lid" d="M 12 36 Q 60 -8 108 36 Z" fill="#c07a38" stroke="#6f3f16" stroke-width="4" />
-              <rect x="52" y="40" width="16" height="26" rx="3" fill="#ffd21f" stroke="#b8860b" stroke-width="3" />
+              <rect x="52" y="40" width="16" height="26" rx="3" fill="#fbd444" stroke="#b8860b" stroke-width="3" />
             </svg>
             <span>TAP TO OPEN</span>
           </button>
@@ -518,7 +589,8 @@
             <a class="panel-btn gold" href="mailto:ali.haroon@colorado.edu"><svg class="ico"><use href="#i-mail" /></svg> ali.haroon@colorado.edu</a>
             <a class="panel-btn" href="https://github.com/Ali-Haroon3" target="_blank" rel="noreferrer"><svg class="ico"><use href="#i-code" /></svg> github.com/Ali-Haroon3</a>
             <a class="panel-btn" href="https://www.ali-haroon.com" target="_blank" rel="noreferrer"><svg class="ico"><use href="#i-globe" /></svg> ali-haroon.com</a>
-            <p class="chest-note">US Citizen &bull; open to 2026 opportunities</p>
+            <a class="panel-btn" href="https://cronys.xyz" target="_blank" rel="noreferrer"><svg class="ico"><use href="#i-out" /></svg> cronys.xyz</a>
+            <p class="chest-note">US Citizen &bull; Software Engineer @ Visa &bull; Co-Founder @ Cronys</p>
           </div>
         </div>
       </div>
@@ -527,8 +599,8 @@
     <section class="panel" data-panel="about" hidden aria-label="About Ali">
       <header class="panel-head">
         <div>
-          <h2>RISKY REELS</h2>
-          <p>NOW SHOWING: WHO IS ALI?</p>
+          <h2>LONE LODGE</h2>
+          <p>CHARACTER SELECT: WHO IS ALI?</p>
         </div>
         <button class="panel-close" aria-label="Close"><svg class="ico"><use href="#i-x" /></svg></button>
       </header>
@@ -537,16 +609,18 @@
           <div class="about-avatar" aria-hidden="true">AH</div>
           <div>
             <h3>Ali Haroon</h3>
-            <p class="quest-meta">Senior @ CU Boulder &bull; CS + Math + Biochemistry</p>
+            <p class="quest-meta">Software Engineer @ Visa &bull; Co-Founder @ Cronys &bull; CU Boulder '26</p>
             <p class="about-blurb">
-              I build reliable software systems, data pipelines, and ML-powered products —
-              from distributed infrastructure and observability tooling to full-stack research apps.
-              Main drops: backend systems, data/ML, and anything with a hard problem in the middle.
+              I build reliable software systems, data pipelines, and ML-powered products.
+              Right now that means real-time transaction monitoring at Visa and building
+              Cronys, an AI agent governance platform ($25K pre-seed). CU Boulder grad —
+              computer science with math and biochemistry minors. Main drops: backend
+              systems, distributed infrastructure, and anything with a hard problem in the middle.
             </p>
             <div class="stat-rows">
-              <div class="stat-row"><span>SYSTEMS &amp; INFRA</span><div class="stat-bar"><i style="width:92%"></i></div></div>
+              <div class="stat-row"><span>SYSTEMS &amp; INFRA</span><div class="stat-bar"><i style="width:94%"></i></div></div>
               <div class="stat-row"><span>DATA / ML</span><div class="stat-bar"><i style="width:88%"></i></div></div>
-              <div class="stat-row"><span>FULL-STACK</span><div class="stat-bar"><i style="width:82%"></i></div></div>
+              <div class="stat-row"><span>FULL-STACK</span><div class="stat-bar"><i style="width:84%"></i></div></div>
               <div class="stat-row"><span>BUILD BATTLES</span><div class="stat-bar"><i style="width:34%"></i></div><em>(working on it)</em></div>
             </div>
           </div>

--- a/fortnite/index.html
+++ b/fortnite/index.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ali Haroon | Drop In</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- ============ LOBBY / LOADING SCREEN ============ -->
+    <div id="lobby" class="lobby">
+      <div class="lobby-sky"></div>
+      <div class="lobby-content">
+        <p class="lobby-eyebrow">SEASON 2026 &bull; CHAPTER: SENIOR YEAR</p>
+        <h1 class="lobby-title">ALI<br />HAROON</h1>
+        <p class="lobby-sub">SOFTWARE ENGINEER &bull; CU BOULDER &bull; CS + MATH + BIOCHEM</p>
+        <button id="playBtn" class="play-btn">
+          <span>DROP IN</span>
+        </button>
+        <a class="lobby-classic" href="../index.html">or switch to Classic Mode</a>
+      </div>
+      <div class="lobby-tip">TIP: Click a POI on the map to discover a part of Ali. Find all 6 for a Victory Royale.</div>
+    </div>
+
+    <!-- ============ GAME / MAP SCREEN ============ -->
+    <div id="game" class="game" hidden>
+      <!-- HUD: top bar -->
+      <div class="hud-top">
+        <div class="compass" aria-hidden="true">
+          <div class="compass-strip">
+            <span>W</span><span>&bull;</span><span>NW</span><span>&bull;</span><span>N</span><span>&bull;</span><span>NE</span><span>&bull;</span><span>E</span><span>&bull;</span><span>SE</span><span>&bull;</span><span>S</span><span>&bull;</span><span>SW</span><span>&bull;</span>
+            <span>W</span><span>&bull;</span><span>NW</span><span>&bull;</span><span>N</span><span>&bull;</span><span>NE</span><span>&bull;</span><span>E</span><span>&bull;</span><span>SE</span><span>&bull;</span><span>S</span><span>&bull;</span><span>SW</span><span>&bull;</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- HUD: right column -->
+      <div class="hud-right">
+        <div class="minimap" aria-hidden="true">
+          <svg viewBox="0 0 1600 1000" preserveAspectRatio="xMidYMid slice">
+            <use href="#islandArt" />
+            <circle id="miniStorm" cx="800" cy="500" r="620" class="storm-ring" />
+          </svg>
+        </div>
+        <div class="hud-stats">
+          <div class="hud-stat"><span class="hud-ico">👤</span> 1 recruiter watching</div>
+          <div class="hud-stat"><span class="hud-ico">📍</span> <span id="poiCount">0</span>/6 POIs discovered</div>
+        </div>
+      </div>
+
+      <!-- HUD: bottom left health/shield -->
+      <div class="hud-vitals" aria-hidden="true">
+        <div class="bar shield"><div class="bar-fill"></div><span>100</span></div>
+        <div class="bar health"><div class="bar-fill"></div><span>100</span></div>
+      </div>
+
+      <!-- HUD: bottom right hotbar -->
+      <div class="hotbar">
+        <a class="slot" href="mailto:ali.haroon@colorado.edu" title="Email Ali">✉️<em>Email</em></a>
+        <a class="slot" href="https://github.com/Ali-Haroon3" target="_blank" rel="noreferrer" title="GitHub">🐙<em>GitHub</em></a>
+        <a class="slot" href="https://www.ali-haroon.com" target="_blank" rel="noreferrer" title="Main site">🌐<em>Site</em></a>
+        <a class="slot" href="../index.html" title="Classic portfolio">🕹️<em>Classic</em></a>
+      </div>
+
+      <!-- ============ THE ISLAND MAP ============ -->
+      <div class="map-wrap">
+        <svg id="mapSvg" viewBox="0 0 1600 1000" preserveAspectRatio="xMidYMid meet" role="group" aria-label="Island map of Ali's portfolio">
+          <defs>
+            <radialGradient id="oceanGrad" cx="50%" cy="45%" r="75%">
+              <stop offset="0%" stop-color="#2e9fd9" />
+              <stop offset="70%" stop-color="#1b6fb5" />
+              <stop offset="100%" stop-color="#124f8c" />
+            </radialGradient>
+            <linearGradient id="grassGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#8ecf62" />
+              <stop offset="100%" stop-color="#6fb04a" />
+            </linearGradient>
+            <linearGradient id="towerGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#b9c6d8" />
+              <stop offset="100%" stop-color="#8494ab" />
+            </linearGradient>
+            <linearGradient id="stormGrad" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#b44ee8" />
+              <stop offset="100%" stop-color="#7b2ff7" />
+            </linearGradient>
+            <filter id="dropSh" x="-20%" y="-20%" width="140%" height="140%">
+              <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#0a2a4a" flood-opacity="0.35" />
+            </filter>
+
+            <!-- Reusable tree -->
+            <g id="tree">
+              <rect x="-3" y="6" width="6" height="10" rx="2" fill="#8a5a33" />
+              <circle cx="0" cy="0" r="12" fill="#3f8f3d" />
+              <circle cx="-8" cy="6" r="8" fill="#4aa348" />
+              <circle cx="8" cy="6" r="8" fill="#4aa348" />
+            </g>
+
+            <!-- The island artwork, reused by the minimap -->
+            <g id="islandArt">
+              <rect x="0" y="0" width="1600" height="1000" fill="url(#oceanGrad)" />
+              <!-- wave rings -->
+              <circle cx="800" cy="500" r="560" fill="none" stroke="#ffffff" stroke-opacity="0.08" stroke-width="18" />
+              <circle cx="800" cy="500" r="640" fill="none" stroke="#ffffff" stroke-opacity="0.05" stroke-width="14" />
+
+              <!-- main island: sand then grass -->
+              <path d="M 380 300
+                       C 420 180, 620 120, 800 150
+                       C 980 175, 1180 190, 1280 320
+                       C 1370 435, 1350 600, 1260 710
+                       C 1160 830, 980 900, 800 880
+                       C 620 862, 470 820, 390 690
+                       C 310 560, 330 420, 380 300 Z"
+                    fill="#e8d29a" />
+              <path d="M 410 320
+                       C 448 215, 630 155, 795 182
+                       C 962 208, 1145 222, 1240 335
+                       C 1322 440, 1305 590, 1222 690
+                       C 1128 800, 962 866, 800 848
+                       C 634 830, 500 790, 424 672
+                       C 350 552, 368 428, 410 320 Z"
+                    fill="url(#grassGrad)" />
+
+              <!-- spawn island (offshore) -->
+              <ellipse cx="200" cy="775" rx="105" ry="72" fill="#e8d29a" />
+              <ellipse cx="200" cy="770" rx="88" ry="58" fill="url(#grassGrad)" />
+
+              <!-- lake -->
+              <path d="M 1000 350 C 1060 320, 1160 330, 1190 390 C 1220 450, 1180 510, 1110 520 C 1035 530, 970 490, 965 435 C 962 395, 965 370, 1000 350 Z"
+                    fill="#2e9fd9" stroke="#e8d29a" stroke-width="8" />
+              <ellipse cx="1080" cy="428" rx="26" ry="16" fill="#e8d29a" />
+
+              <!-- river from lake to south shore -->
+              <path d="M 990 470 C 940 560, 950 640, 905 700 C 870 748, 850 790, 845 850"
+                    fill="none" stroke="#2e9fd9" stroke-width="20" stroke-linecap="round" />
+
+              <!-- roads -->
+              <g fill="none" stroke="#d9c48f" stroke-width="14" stroke-linecap="round" stroke-dasharray="none" opacity="0.9">
+                <path d="M 620 290 C 680 360, 740 430, 800 505" />
+                <path d="M 800 505 C 900 560, 900 660, 905 730" />
+                <path d="M 800 505 C 890 480, 960 460, 1035 445" />
+                <path d="M 360 400 C 460 430, 640 480, 780 510" />
+              </g>
+
+              <!-- Boulder Bluffs mountains -->
+              <g transform="translate(330,370)">
+                <path d="M -80 60 L -10 -70 L 55 60 Z" fill="#9aa7b8" />
+                <path d="M -10 -70 L -34 -20 L 14 -20 Z" fill="#f2f6fa" />
+                <path d="M 10 60 L 70 -35 L 125 60 Z" fill="#8794a6" />
+                <path d="M 70 -35 L 52 0 L 88 0 Z" fill="#eef3f8" />
+              </g>
+
+              <!-- Pleasant Projects houses -->
+              <g transform="translate(620,235)">
+                <g filter="url(#dropSh)">
+                  <rect x="-55" y="0" width="44" height="34" fill="#e5eef7" />
+                  <path d="M -60 0 L -33 -24 L -6 0 Z" fill="#d94f4f" />
+                  <rect x="8" y="6" width="44" height="30" fill="#f3e3c6" />
+                  <path d="M 3 6 L 30 -16 L 57 6 Z" fill="#4f78d9" />
+                </g>
+              </g>
+
+              <!-- Tilted Tech Towers -->
+              <g transform="translate(800,500)" filter="url(#dropSh)">
+                <rect x="-58" y="-70" width="34" height="88" fill="url(#towerGrad)" transform="rotate(-4 -41 -26)" />
+                <rect x="-14" y="-98" width="40" height="116" fill="url(#towerGrad)" />
+                <rect x="34" y="-58" width="30" height="76" fill="url(#towerGrad)" transform="rotate(4 49 -20)" />
+                <g fill="#ffd54d">
+                  <rect x="-8" y="-88" width="8" height="8" /><rect x="8" y="-88" width="8" height="8" />
+                  <rect x="-8" y="-68" width="8" height="8" /><rect x="8" y="-48" width="8" height="8" />
+                  <rect x="-52" y="-58" width="7" height="7" /><rect x="-40" y="-38" width="7" height="7" />
+                  <rect x="40" y="-46" width="6" height="6" /><rect x="40" y="-28" width="6" height="6" />
+                </g>
+              </g>
+
+              <!-- Salty Skills Springs -->
+              <g transform="translate(905,755)">
+                <ellipse cx="-30" cy="10" rx="26" ry="14" fill="#57c7e8" stroke="#e8d29a" stroke-width="5" />
+                <ellipse cx="34" cy="-4" rx="20" ry="11" fill="#57c7e8" stroke="#e8d29a" stroke-width="5" />
+                <g filter="url(#dropSh)">
+                  <rect x="-8" y="-38" width="38" height="26" fill="#f3e3c6" />
+                  <path d="M -13 -38 L 11 -56 L 35 -38 Z" fill="#d98a3f" />
+                </g>
+              </g>
+
+              <!-- Loot Lake chest island -->
+              <g transform="translate(1080,420)" filter="url(#dropSh)">
+                <rect x="-16" y="-10" width="32" height="20" rx="3" fill="#a8642c" />
+                <path d="M -16 -10 Q 0 -26 16 -10 Z" fill="#c07a38" />
+                <rect x="-3" y="-8" width="6" height="16" fill="#ffd54d" />
+              </g>
+
+              <!-- trees scattered -->
+              <use href="#tree" transform="translate(520,560)" />
+              <use href="#tree" transform="translate(700,660) scale(0.85)" />
+              <use href="#tree" transform="translate(1150,610) scale(0.9)" />
+              <use href="#tree" transform="translate(1210,540) scale(0.7)" />
+              <use href="#tree" transform="translate(560,250) scale(0.8)" />
+              <use href="#tree" transform="translate(980,250) scale(0.85)" />
+              <use href="#tree" transform="translate(450,520) scale(0.75)" />
+              <use href="#tree" transform="translate(1100,700) scale(0.8)" />
+
+              <!-- spawn island props -->
+              <use href="#tree" transform="translate(170,750) scale(0.7)" />
+              <g transform="translate(228,764)">
+                <rect x="-2" y="-34" width="4" height="34" fill="#8a5a33" />
+                <path d="M 2 -34 L 34 -26 L 2 -18 Z" fill="#4f78d9" />
+              </g>
+            </g>
+          </defs>
+
+          <!-- visible map -->
+          <use href="#islandArt" />
+
+          <!-- storm circle -->
+          <g class="storm">
+            <circle id="stormCircle" cx="800" cy="500" r="620" fill="none" stroke="url(#stormGrad)" stroke-width="10" opacity="0.85" />
+          </g>
+
+          <!-- ============ CLICKABLE POI HOTSPOTS ============ -->
+          <g id="poiLayer">
+            <g class="poi" data-poi="education" tabindex="0" role="button" aria-label="Boulder Bluffs: Education">
+              <circle cx="345" cy="395" r="95" class="poi-hit" />
+              <text x="345" y="475" class="poi-label">BOULDER BLUFFS</text>
+              <text x="345" y="497" class="poi-tag">EDUCATION</text>
+            </g>
+            <g class="poi" data-poi="projects" tabindex="0" role="button" aria-label="Pleasant Projects: Projects">
+              <circle cx="630" cy="245" r="85" class="poi-hit" />
+              <text x="630" y="330" class="poi-label">PLEASANT PROJECTS</text>
+              <text x="630" y="352" class="poi-tag">PROJECTS</text>
+            </g>
+            <g class="poi" data-poi="experience" tabindex="0" role="button" aria-label="Tilted Tech Towers: Experience">
+              <circle cx="800" cy="470" r="100" class="poi-hit" />
+              <text x="800" y="580" class="poi-label">TILTED TECH TOWERS</text>
+              <text x="800" y="602" class="poi-tag">EXPERIENCE</text>
+            </g>
+            <g class="poi" data-poi="contact" tabindex="0" role="button" aria-label="Loot Lake Links: Contact">
+              <circle cx="1080" cy="425" r="90" class="poi-hit" />
+              <text x="1080" y="530" class="poi-label">LOOT LAKE LINKS</text>
+              <text x="1080" y="552" class="poi-tag">CONTACT</text>
+            </g>
+            <g class="poi" data-poi="skills" tabindex="0" role="button" aria-label="Salty Skills Springs: Skills">
+              <circle cx="905" cy="745" r="90" class="poi-hit" />
+              <text x="905" y="840" class="poi-label">SALTY SKILLS SPRINGS</text>
+              <text x="905" y="862" class="poi-tag">SKILLS</text>
+            </g>
+            <g class="poi" data-poi="about" tabindex="0" role="button" aria-label="Spawn Island: About Ali">
+              <circle cx="200" cy="770" r="90" class="poi-hit" />
+              <text x="200" y="880" class="poi-label">SPAWN ISLAND</text>
+              <text x="200" y="902" class="poi-tag">ABOUT ME</text>
+            </g>
+          </g>
+
+          <!-- battle bus -->
+          <g id="battleBus" class="battle-bus" aria-hidden="true">
+            <path d="M 0 -46 Q -34 -78 0 -92 Q 34 -78 0 -46 Z" fill="#7b2ff7" stroke="#5a1fd0" stroke-width="3" />
+            <line x1="-14" y1="-52" x2="-10" y2="-24" stroke="#333" stroke-width="2.5" />
+            <line x1="14" y1="-52" x2="10" y2="-24" stroke="#333" stroke-width="2.5" />
+            <rect x="-38" y="-24" width="76" height="34" rx="8" fill="#4f78d9" stroke="#2d4fa3" stroke-width="3" />
+            <rect x="-30" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
+            <rect x="-9" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
+            <rect x="12" y="-16" width="14" height="12" rx="2" fill="#cfe6ff" />
+            <circle cx="-22" cy="12" r="7" fill="#222" /><circle cx="22" cy="12" r="7" fill="#222" />
+          </g>
+        </svg>
+      </div>
+
+      <!-- Victory banner -->
+      <div id="victory" class="victory" hidden>
+        <div class="victory-inner">
+          <p class="victory-hash">#1</p>
+          <p class="victory-title">VICTORY ROYALE</p>
+          <p class="victory-sub">You discovered every POI. Time to recruit Ali.</p>
+          <a class="panel-btn gold" href="mailto:ali.haroon@colorado.edu">SEND THE INVITE ✉️</a>
+          <button class="victory-close" id="victoryClose">Keep exploring</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============ POI PANELS ============ -->
+    <div id="panelBackdrop" class="panel-backdrop" hidden></div>
+
+    <section class="panel" data-panel="experience" hidden aria-label="Experience">
+      <header class="panel-head">
+        <div>
+          <h2>TILTED TECH TOWERS</h2>
+          <p>QUESTLINE: WORK EXPERIENCE</p>
+        </div>
+        <button class="panel-close" aria-label="Close">✕</button>
+      </header>
+      <div class="panel-body">
+        <article class="quest legendary">
+          <div class="quest-top">
+            <h3>Vantor — Software Development Intern</h3>
+            <span class="rarity-pill">LEGENDARY QUEST</span>
+          </div>
+          <p class="quest-meta">Westminster, CO &bull; Jun 2025 – Aug 2025</p>
+          <ul class="quest-list">
+            <li><span class="check">✔</span> Engineered distributed infrastructure for 6 satellite ground-station monitoring environments with Java + Kubernetes <b class="xp">−30% incident response time</b></li>
+            <li><span class="check">✔</span> Built observability dashboards with Grafana, Prometheus, and Java collectors <b class="xp">35 production services</b></li>
+            <li><span class="check">✔</span> Designed automated testing workflows for 15+ Linux microservices with Jenkins CI/CD <b class="xp">+10,000 XP</b></li>
+            <li><span class="check">✔</span> Implemented Spring Boot APIs for low-latency inference <b class="xp">1K+ req/min</b></li>
+          </ul>
+        </article>
+
+        <article class="quest epic">
+          <div class="quest-top">
+            <h3>CUChange — Data Management Research Assistant</h3>
+            <span class="rarity-pill">EPIC QUEST &bull; ACTIVE</span>
+          </div>
+          <p class="quest-meta">Boulder, CO &bull; Jul 2025 – Present</p>
+          <ul class="quest-list">
+            <li><span class="check">✔</span> Developed full-stack Django apps with PostgreSQL on GCP <b class="xp">50K+ research records</b></li>
+            <li><span class="check">✔</span> Built automated pipelines with Python, pandas, and the REDCap API for large-scale cleaning + transformation <b class="xp">+8,000 XP</b></li>
+            <li><span class="check">✔</span> Designed migration &amp; reporting workflows <b class="xp">+300% processing speed</b></li>
+          </ul>
+        </article>
+
+        <article class="quest rare">
+          <div class="quest-top">
+            <h3>ReportsNow — Software Engineering Intern</h3>
+            <span class="rarity-pill">RARE QUEST</span>
+          </div>
+          <p class="quest-meta">Greenwood Village, CO &bull; May 2024 – Jul 2024</p>
+          <ul class="quest-list">
+            <li><span class="check">✔</span> Built a BI platform with C#, ASP.NET Core, and React <b class="xp">125+ client systems</b></li>
+            <li><span class="check">✔</span> Optimized a SQL Server analytics stack with Entity Framework <b class="xp">500+ daily queries</b></li>
+            <li><span class="check">✔</span> Implemented Azure DevOps + Docker CI/CD in Agile/SCRUM workflows <b class="xp">+6,000 XP</b></li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel" data-panel="projects" hidden aria-label="Projects">
+      <header class="panel-head">
+        <div>
+          <h2>PLEASANT PROJECTS</h2>
+          <p>LOOT DROPS: THINGS I BUILT</p>
+        </div>
+        <button class="panel-close" aria-label="Close">✕</button>
+      </header>
+      <div class="panel-body loot-grid">
+        <article class="loot legendary">
+          <span class="rarity-pill">LEGENDARY</span>
+          <h3>Polymarket Weather Prediction</h3>
+          <p>Prediction-market weather model trading on real Polymarket data.</p>
+          <p class="loot-stack">Rust &bull; Python &bull; NumPy &bull; pandas &bull; Scikit-learn &bull; PostgreSQL</p>
+          <a class="panel-btn" href="https://github.com/Ali-Haroon3/Polymarket-Weather-Predictor" target="_blank" rel="noreferrer">INSPECT ON GITHUB ↗</a>
+        </article>
+        <article class="loot epic">
+          <span class="rarity-pill">EPIC</span>
+          <h3>BlackjackTrainer</h3>
+          <p>AI-assisted blackjack strategy trainer, deployed on AWS.</p>
+          <p class="loot-stack">Python &bull; Flask &bull; JavaScript &bull; AWS</p>
+          <a class="panel-btn" href="https://github.com/Ali-Haroon3/AIBlackJackTrainer" target="_blank" rel="noreferrer">INSPECT ON GITHUB ↗</a>
+        </article>
+        <article class="loot epic">
+          <span class="rarity-pill">EPIC</span>
+          <h3>Lung Cancer Detection</h3>
+          <p>Deep-learning imaging classifier with an interactive Streamlit front end.</p>
+          <p class="loot-stack">Python &bull; TensorFlow &bull; Streamlit &bull; PostgreSQL</p>
+          <a class="panel-btn" href="https://github.com/Ali-Haroon3/Lung-Cancer-Detection" target="_blank" rel="noreferrer">INSPECT ON GITHUB ↗</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel" data-panel="skills" hidden aria-label="Skills">
+      <header class="panel-head">
+        <div>
+          <h2>SALTY SKILLS SPRINGS</h2>
+          <p>LOCKER: EQUIPPED SKILLS</p>
+        </div>
+        <button class="panel-close" aria-label="Close">✕</button>
+      </header>
+      <div class="panel-body">
+        <div class="inv-grid">
+          <span class="inv legendary">Python</span>
+          <span class="inv legendary">Rust</span>
+          <span class="inv legendary">Java</span>
+          <span class="inv epic">C#</span>
+          <span class="inv epic">SQL</span>
+          <span class="inv epic">JavaScript</span>
+          <span class="inv epic">TensorFlow</span>
+          <span class="inv epic">PyTorch</span>
+          <span class="inv rare">Scikit-learn</span>
+          <span class="inv rare">Kubernetes</span>
+          <span class="inv rare">Docker</span>
+          <span class="inv rare">AWS</span>
+          <span class="inv uncommon">Jenkins</span>
+          <span class="inv uncommon">Azure DevOps</span>
+          <span class="inv uncommon">PostgreSQL</span>
+          <span class="inv common">Grafana</span>
+          <span class="inv common">Prometheus</span>
+        </div>
+        <p class="inv-note">Rarity = how often it's in my main loadout, not how much I like it. Prometheus, you're still loved.</p>
+      </div>
+    </section>
+
+    <section class="panel" data-panel="education" hidden aria-label="Education">
+      <header class="panel-head">
+        <div>
+          <h2>BOULDER BLUFFS</h2>
+          <p>TRAINING GROUNDS: EDUCATION</p>
+        </div>
+        <button class="panel-close" aria-label="Close">✕</button>
+      </header>
+      <div class="panel-body">
+        <article class="quest legendary">
+          <div class="quest-top">
+            <h3>University of Colorado Boulder</h3>
+            <span class="rarity-pill">SENIOR &bull; LEVEL 4/4</span>
+          </div>
+          <p class="quest-meta">Boulder, CO &bull; the real Boulder Bluffs</p>
+          <ul class="quest-list">
+            <li><span class="check">✔</span> B.S. Computer Science <b class="xp">MAIN CLASS</b></li>
+            <li><span class="check">✔</span> Mathematics <b class="xp">DUAL WIELD</b></li>
+            <li><span class="check">✔</span> Biochemistry <b class="xp">THIRD SLOT</b></li>
+          </ul>
+          <div class="xp-bar"><div class="xp-fill"></div><span>SEASON PROGRESS: SENIOR YEAR</span></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel" data-panel="contact" hidden aria-label="Contact">
+      <header class="panel-head">
+        <div>
+          <h2>LOOT LAKE LINKS</h2>
+          <p>OPEN THE CHEST: CONTACT ALI</p>
+        </div>
+        <button class="panel-close" aria-label="Close">✕</button>
+      </header>
+      <div class="panel-body">
+        <div id="chestZone" class="chest-zone">
+          <button id="chestBtn" class="chest-btn" aria-label="Open the chest">
+            <svg viewBox="0 0 120 90" width="150" height="112">
+              <rect x="12" y="34" width="96" height="48" rx="6" fill="#a8642c" stroke="#6f3f16" stroke-width="4" />
+              <path class="chest-lid" d="M 12 36 Q 60 -8 108 36 Z" fill="#c07a38" stroke="#6f3f16" stroke-width="4" />
+              <rect x="52" y="40" width="16" height="26" rx="3" fill="#ffd54d" stroke="#b8860b" stroke-width="3" />
+            </svg>
+            <span>TAP TO OPEN</span>
+          </button>
+          <div class="chest-loot" hidden>
+            <a class="panel-btn gold" href="mailto:ali.haroon@colorado.edu">✉️ ali.haroon@colorado.edu</a>
+            <a class="panel-btn" href="https://github.com/Ali-Haroon3" target="_blank" rel="noreferrer">🐙 github.com/Ali-Haroon3</a>
+            <a class="panel-btn" href="https://www.ali-haroon.com" target="_blank" rel="noreferrer">🌐 ali-haroon.com</a>
+            <p class="chest-note">US Citizen &bull; open to 2026 opportunities</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel" data-panel="about" hidden aria-label="About Ali">
+      <header class="panel-head">
+        <div>
+          <h2>SPAWN ISLAND</h2>
+          <p>CHARACTER SELECT: WHO IS ALI?</p>
+        </div>
+        <button class="panel-close" aria-label="Close">✕</button>
+      </header>
+      <div class="panel-body">
+        <div class="about-card">
+          <div class="about-avatar" aria-hidden="true">AH</div>
+          <div>
+            <h3>Ali Haroon</h3>
+            <p class="quest-meta">Senior @ CU Boulder &bull; CS + Math + Biochemistry</p>
+            <p class="about-blurb">
+              I build reliable software systems, data pipelines, and ML-powered products —
+              from distributed infrastructure and observability tooling to full-stack research apps.
+              Main drops: backend systems, data/ML, and anything with a hard problem in the middle.
+            </p>
+            <div class="stat-rows">
+              <div class="stat-row"><span>SYSTEMS &amp; INFRA</span><div class="stat-bar"><i style="width:92%"></i></div></div>
+              <div class="stat-row"><span>DATA / ML</span><div class="stat-bar"><i style="width:88%"></i></div></div>
+              <div class="stat-row"><span>FULL-STACK</span><div class="stat-bar"><i style="width:82%"></i></div></div>
+              <div class="stat-row"><span>BUILD BATTLES</span><div class="stat-bar"><i style="width:34%"></i></div><em>(working on it)</em></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/fortnite/script.js
+++ b/fortnite/script.js
@@ -1,22 +1,63 @@
 const lobby = document.getElementById('lobby');
 const game = document.getElementById('game');
 const playBtn = document.getElementById('playBtn');
-const bus = document.getElementById('battleBus');
-const stormCircle = document.getElementById('stormCircle');
+const realStage = document.getElementById('realStage');
+const fallbackStage = document.getElementById('fallbackStage');
+const mapImg = document.getElementById('mapImg');
+const miniImg = document.getElementById('miniImg');
+const miniFallback = document.getElementById('miniFallback');
 const miniStorm = document.getElementById('miniStorm');
+const stormReal = document.getElementById('stormReal');
+const stormCircle = document.getElementById('stormCircle');
+const busReal = document.getElementById('busReal');
+const busFallback = document.getElementById('busFallback');
 const poiCount = document.getElementById('poiCount');
 const backdrop = document.getElementById('panelBackdrop');
 const victory = document.getElementById('victory');
 const victoryClose = document.getElementById('victoryClose');
-const pois = [...document.querySelectorAll('.poi')];
 const panels = [...document.querySelectorAll('.panel')];
+
+// Chapter 1 Season 7 map, loaded at runtime from the fortnite-archives project
+// (https://github.com/yaelbrinkert/fortnite-archives). Nothing is bundled with
+// this repo; if the image can't load we fall back to the hand-drawn island.
+const MAP_URL =
+  new URLSearchParams(location.search).get('mapimg') ||
+  'https://raw.githubusercontent.com/yaelbrinkert/fortnite-archives/main/chapter_1/season_7/7_00/7_00.jpg';
 
 const visited = new Set();
 let victoryShown = false;
 let openPanel = null;
+let realMode = false;
+let mapReady = null; // promise resolving true (real map) / false (fallback)
+
+/* ---------- preload the real map while the player sits in the lobby ---------- */
+function preloadMap() {
+  mapReady = new Promise((resolve) => {
+    const img = new Image();
+    const timer = setTimeout(() => resolve(false), 8000);
+    img.onload = () => { clearTimeout(timer); resolve(true); };
+    img.onerror = () => { clearTimeout(timer); resolve(false); };
+    img.src = MAP_URL;
+  });
+}
+preloadMap();
 
 /* ---------- lobby → game ---------- */
-playBtn.addEventListener('click', () => {
+playBtn.addEventListener('click', async () => {
+  playBtn.disabled = true;
+  const useReal = await mapReady;
+  realMode = useReal;
+
+  if (useReal) {
+    mapImg.src = MAP_URL;
+    miniImg.src = MAP_URL;
+    miniImg.hidden = false;
+    miniFallback.setAttribute('hidden', '');
+    realStage.hidden = false;
+  } else {
+    fallbackStage.hidden = false;
+  }
+
   lobby.classList.add('leaving');
   game.hidden = false;
   setTimeout(() => { lobby.remove(); }, 550);
@@ -26,22 +67,25 @@ playBtn.addEventListener('click', () => {
 
 /* ---------- battle bus intro ---------- */
 function flyBattleBus() {
-  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (reduced) return;
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-  bus.classList.add('flying');
+  const bus = realMode ? busReal : busFallback;
+  const span = realMode ? 4096 : 1600; // horizontal span of each map's coordinate space
+  const baseY = realMode ? 900 : 210;
+  const wave = realMode ? 70 : 26;
   const start = performance.now();
   const duration = 6000;
 
+  bus.setAttribute('opacity', '1');
   function frame(now) {
     const t = Math.min((now - start) / duration, 1);
-    const x = -120 + t * 1840;
-    const y = 210 + Math.sin(t * Math.PI * 2) * 26;
+    const x = -0.08 * span + t * span * 1.16;
+    const y = baseY + Math.sin(t * Math.PI * 2) * wave;
     bus.setAttribute('transform', `translate(${x} ${y})`);
     if (t < 1) {
       requestAnimationFrame(frame);
     } else {
-      bus.classList.remove('flying');
+      bus.setAttribute('opacity', '0');
     }
   }
   requestAnimationFrame(frame);
@@ -49,24 +93,28 @@ function flyBattleBus() {
 
 /* ---------- storm circle: slow shrink + reset loop ---------- */
 function startStorm() {
-  const MAX_R = 620;
-  const MIN_R = 190;
-  const CYCLE = 90000; // 90s per "storm phase"
+  const CYCLE = 90000; // 90s per storm phase
   const start = performance.now();
 
   function frame(now) {
     const t = ((now - start) % CYCLE) / CYCLE;
-    // ease: hold, shrink, hold
-    const phase = t < 0.2 ? 0 : t > 0.9 ? 1 : (t - 0.2) / 0.7;
-    const r = MAX_R - (MAX_R - MIN_R) * phase;
-    stormCircle.setAttribute('r', r);
-    miniStorm.setAttribute('r', r);
+    const phase = t < 0.2 ? 0 : t > 0.9 ? 1 : (t - 0.2) / 0.7; // hold, shrink, hold
+    if (realMode) {
+      stormReal.setAttribute('r', 2400 - (2400 - 700) * phase);
+    } else {
+      stormCircle.setAttribute('r', 620 - (620 - 190) * phase);
+    }
+    miniStorm.setAttribute('r', 46 - (46 - 15) * phase);
     requestAnimationFrame(frame);
   }
   requestAnimationFrame(frame);
 }
 
 /* ---------- POI → panel ---------- */
+function poiElements(name) {
+  return document.querySelectorAll(`.poi[data-poi="${name}"], .spot[data-poi="${name}"]`);
+}
+
 function showPanel(name) {
   const panel = panels.find((p) => p.dataset.panel === name);
   if (!panel) return;
@@ -79,8 +127,7 @@ function showPanel(name) {
   if (!visited.has(name)) {
     visited.add(name);
     poiCount.textContent = visited.size;
-    const poi = pois.find((p) => p.dataset.poi === name);
-    if (poi) poi.classList.add('visited');
+    poiElements(name).forEach((el) => el.classList.add('visited'));
   }
 }
 
@@ -92,7 +139,10 @@ function closePanel() {
   maybeVictory();
 }
 
-pois.forEach((poi) => {
+document.querySelectorAll('.spot').forEach((spot) => {
+  spot.addEventListener('click', () => showPanel(spot.dataset.poi));
+});
+document.querySelectorAll('.poi').forEach((poi) => {
   poi.addEventListener('click', () => showPanel(poi.dataset.poi));
   poi.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -119,12 +169,13 @@ const chestLoot = document.querySelector('.chest-loot');
 chestBtn.addEventListener('click', () => {
   chestBtn.hidden = true;
   chestLoot.hidden = false;
-  burstConfetti(40, chestLoot);
+  burstConfetti(40);
 });
 
 /* ---------- victory royale ---------- */
+const TOTAL_POIS = 6;
 function maybeVictory() {
-  if (victoryShown || visited.size < pois.length) return;
+  if (victoryShown || visited.size < TOTAL_POIS) return;
   victoryShown = true;
   victory.hidden = false;
   burstConfetti(120);
@@ -135,7 +186,7 @@ function hideVictory() {
 }
 victoryClose.addEventListener('click', hideVictory);
 
-const CONFETTI_COLORS = ['#ffd54d', '#7b2ff7', '#3fa9ff', '#52d95e', '#ff9d2e', '#ffffff'];
+const CONFETTI_COLORS = ['#ffd21f', '#8547e8', '#37a5ff', '#60aa3a', '#e98d4b', '#ffffff'];
 function burstConfetti(count) {
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
   for (let i = 0; i < count; i++) {

--- a/fortnite/script.js
+++ b/fortnite/script.js
@@ -17,12 +17,13 @@ const victory = document.getElementById('victory');
 const victoryClose = document.getElementById('victoryClose');
 const panels = [...document.querySelectorAll('.panel')];
 
-// Chapter 1 Season 7 map, loaded at runtime from the fortnite-archives project
-// (https://github.com/yaelbrinkert/fortnite-archives). Nothing is bundled with
-// this repo; if the image can't load we fall back to the hand-drawn island.
+// Fortnite Reload island (codename BlastBerry), loaded at runtime from the
+// fortnite-archives project (https://github.com/yaelbrinkert/fortnite-archives).
+// Nothing is bundled with this repo; if the image can't load we fall back to
+// the hand-drawn island.
 const MAP_URL =
   new URLSearchParams(location.search).get('mapimg') ||
-  'https://raw.githubusercontent.com/yaelbrinkert/fortnite-archives/main/chapter_1/season_7/7_00/7_00.jpg';
+  'https://raw.githubusercontent.com/yaelbrinkert/fortnite-archives/main/latest/blastberry_latest.png';
 
 const visited = new Set();
 let victoryShown = false;

--- a/fortnite/script.js
+++ b/fortnite/script.js
@@ -1,0 +1,152 @@
+const lobby = document.getElementById('lobby');
+const game = document.getElementById('game');
+const playBtn = document.getElementById('playBtn');
+const bus = document.getElementById('battleBus');
+const stormCircle = document.getElementById('stormCircle');
+const miniStorm = document.getElementById('miniStorm');
+const poiCount = document.getElementById('poiCount');
+const backdrop = document.getElementById('panelBackdrop');
+const victory = document.getElementById('victory');
+const victoryClose = document.getElementById('victoryClose');
+const pois = [...document.querySelectorAll('.poi')];
+const panels = [...document.querySelectorAll('.panel')];
+
+const visited = new Set();
+let victoryShown = false;
+let openPanel = null;
+
+/* ---------- lobby → game ---------- */
+playBtn.addEventListener('click', () => {
+  lobby.classList.add('leaving');
+  game.hidden = false;
+  setTimeout(() => { lobby.remove(); }, 550);
+  flyBattleBus();
+  startStorm();
+});
+
+/* ---------- battle bus intro ---------- */
+function flyBattleBus() {
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (reduced) return;
+
+  bus.classList.add('flying');
+  const start = performance.now();
+  const duration = 6000;
+
+  function frame(now) {
+    const t = Math.min((now - start) / duration, 1);
+    const x = -120 + t * 1840;
+    const y = 210 + Math.sin(t * Math.PI * 2) * 26;
+    bus.setAttribute('transform', `translate(${x} ${y})`);
+    if (t < 1) {
+      requestAnimationFrame(frame);
+    } else {
+      bus.classList.remove('flying');
+    }
+  }
+  requestAnimationFrame(frame);
+}
+
+/* ---------- storm circle: slow shrink + reset loop ---------- */
+function startStorm() {
+  const MAX_R = 620;
+  const MIN_R = 190;
+  const CYCLE = 90000; // 90s per "storm phase"
+  const start = performance.now();
+
+  function frame(now) {
+    const t = ((now - start) % CYCLE) / CYCLE;
+    // ease: hold, shrink, hold
+    const phase = t < 0.2 ? 0 : t > 0.9 ? 1 : (t - 0.2) / 0.7;
+    const r = MAX_R - (MAX_R - MIN_R) * phase;
+    stormCircle.setAttribute('r', r);
+    miniStorm.setAttribute('r', r);
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+}
+
+/* ---------- POI → panel ---------- */
+function showPanel(name) {
+  const panel = panels.find((p) => p.dataset.panel === name);
+  if (!panel) return;
+  closePanel();
+  panel.hidden = false;
+  backdrop.hidden = false;
+  openPanel = panel;
+  panel.querySelector('.panel-close').focus({ preventScroll: true });
+
+  if (!visited.has(name)) {
+    visited.add(name);
+    poiCount.textContent = visited.size;
+    const poi = pois.find((p) => p.dataset.poi === name);
+    if (poi) poi.classList.add('visited');
+  }
+}
+
+function closePanel() {
+  if (!openPanel) return;
+  openPanel.hidden = true;
+  backdrop.hidden = true;
+  openPanel = null;
+  maybeVictory();
+}
+
+pois.forEach((poi) => {
+  poi.addEventListener('click', () => showPanel(poi.dataset.poi));
+  poi.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      showPanel(poi.dataset.poi);
+    }
+  });
+});
+
+panels.forEach((panel) => {
+  panel.querySelector('.panel-close').addEventListener('click', closePanel);
+});
+backdrop.addEventListener('click', closePanel);
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    if (openPanel) closePanel();
+    else if (!victory.hidden) hideVictory();
+  }
+});
+
+/* ---------- chest (contact) ---------- */
+const chestBtn = document.getElementById('chestBtn');
+const chestLoot = document.querySelector('.chest-loot');
+chestBtn.addEventListener('click', () => {
+  chestBtn.hidden = true;
+  chestLoot.hidden = false;
+  burstConfetti(40, chestLoot);
+});
+
+/* ---------- victory royale ---------- */
+function maybeVictory() {
+  if (victoryShown || visited.size < pois.length) return;
+  victoryShown = true;
+  victory.hidden = false;
+  burstConfetti(120);
+}
+
+function hideVictory() {
+  victory.hidden = true;
+}
+victoryClose.addEventListener('click', hideVictory);
+
+const CONFETTI_COLORS = ['#ffd54d', '#7b2ff7', '#3fa9ff', '#52d95e', '#ff9d2e', '#ffffff'];
+function burstConfetti(count) {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  for (let i = 0; i < count; i++) {
+    const piece = document.createElement('div');
+    piece.className = 'confetti';
+    piece.style.left = `${Math.random() * 100}vw`;
+    piece.style.background = CONFETTI_COLORS[i % CONFETTI_COLORS.length];
+    piece.style.animationDuration = `${2.2 + Math.random() * 2.2}s`;
+    piece.style.animationDelay = `${Math.random() * 0.8}s`;
+    piece.style.transform = `rotate(${Math.random() * 360}deg)`;
+    document.body.appendChild(piece);
+    piece.addEventListener('animationend', () => piece.remove());
+  }
+}

--- a/fortnite/styles.css
+++ b/fortnite/styles.css
@@ -1,18 +1,27 @@
+/* Palette notes:
+   - ocean/grass sampled directly from the Reload map texture (#103a8c, #267215/#318218)
+   - rarity colors are the standard Fortnite set used by fortnite-api and tracker sites
+   - UI chrome follows Fortnite's flat dark-navy menus with bright yellow CTAs
+   - no gradient blends anywhere: flat fills, hard offset shadows, clip-path angles */
 :root {
-  --ink: #0b1530;
-  --panel: #141d45;
-  --panel-2: #1b2657;
-  --line: #3c4a86;
-  --text: #f5f7ff;
-  --muted: #aab6e0;
-  --gold: #ffd21f;
-  --gold-deep: #c99a00;
-  --legendary: #e98d4b;
-  --epic: #a855f7;
-  --rare: #37a5ff;
-  --uncommon: #60aa3a;
+  --ocean: #103a8c;
+  --ocean-deep: #0d2f73;
+  --ink: #101423;
+  --panel: #191e2e;
+  --panel-2: #232a3f;
+  --line: #3a4258;
+  --text: #ffffff;
+  --muted: #a8b0c4;
+  --yellow: #fff200;
+  --gold: #fbd444;
+  --gold-deep: #b8860b;
+  --mythic: #fbd444;
+  --legendary: #ea8d23;
+  --epic: #c359ff;
+  --rare: #41bfff;
+  --uncommon: #87e339;
   --common: #b1b1b1;
-  --storm: #8547e8;
+  --storm: #b04df9;
 }
 
 * { box-sizing: border-box; }
@@ -28,7 +37,7 @@ body {
 
 .lobby-title, .play-btn span, .poi-label, .panel-head h2,
 .victory-title, .victory-hash, .rarity-pill, .lobby-eyebrow,
-.spot-name, .chest-btn span {
+.spot-name, .chest-btn span, .aisle-name {
   font-family: Anton, Inter, sans-serif;
   letter-spacing: 0.04em;
 }
@@ -43,63 +52,55 @@ body {
   transition: opacity .5s ease, transform .5s ease;
 }
 .lobby.leaving { opacity: 0; transform: scale(1.06); pointer-events: none; }
-/* flat royal blue with hard-edged diagonal stripes, like the Ch1 lobby */
-.lobby-sky {
-  position: absolute; inset: 0;
-  background: #2440b8;
-}
-.lobby-sky::after {
-  content: "";
-  position: absolute; inset: 0;
-  background: repeating-linear-gradient(
-    115deg,
-    transparent 0 90px,
-    #1f39a6 90px 180px
-  );
-}
+/* flat ocean blue (sampled from the map) with two flat darker slashes */
+.lobby-sky { position: absolute; inset: 0; background: var(--ocean); }
+.slash { position: absolute; top: -20%; bottom: -20%; background: var(--ocean-deep); transform: rotate(24deg); }
+.slash-1 { left: -6%; width: 34%; }
+.slash-2 { right: -14%; width: 22%; }
+
 .lobby-content { position: relative; text-align: center; padding: 1rem; }
-.lobby-eyebrow { color: var(--gold); font-size: clamp(.95rem, 2vw, 1.2rem); margin: 0 0 .4rem; letter-spacing: .1em; }
+.lobby-eyebrow { color: var(--yellow); font-size: clamp(.95rem, 2vw, 1.2rem); margin: 0 0 .4rem; letter-spacing: .1em; }
 .lobby-title {
   font-size: clamp(3.4rem, 12vw, 8rem);
   line-height: .92; margin: 0;
   transform: skewX(-6deg);
   color: #ffffff;
-  text-shadow: 5px 5px 0 #0b1530;
+  text-shadow: 5px 5px 0 var(--ink);
 }
-.lobby-sub { color: #dbe3ff; font-weight: 700; margin: 1rem 0 2rem; font-size: clamp(.8rem, 2vw, 1rem); letter-spacing: .12em; }
+.lobby-sub { color: #ffffff; font-weight: 700; margin: 1rem 0 2rem; font-size: clamp(.75rem, 2vw, 1rem); letter-spacing: .12em; }
 
 .play-btn {
   cursor: pointer; border: none;
-  background: var(--gold);
+  background: var(--yellow);
   color: #1c1500;
   padding: 1rem 3.4rem;
   clip-path: polygon(6% 0, 100% 0, 94% 100%, 0 100%);
-  box-shadow: 6px 6px 0 #0b1530;
+  box-shadow: 6px 6px 0 var(--ink);
   transition: transform .12s ease, box-shadow .12s ease;
 }
 .play-btn span { font-size: clamp(1.6rem, 4vw, 2.4rem); transform: skewX(-6deg); display: inline-block; }
-.play-btn:hover { transform: translate(2px, 2px); box-shadow: 4px 4px 0 #0b1530; background: #ffdc4d; }
-.play-btn:active { transform: translate(6px, 6px); box-shadow: 0 0 0 #0b1530; }
+.play-btn:hover { transform: translate(2px, 2px); box-shadow: 4px 4px 0 var(--ink); }
+.play-btn:active { transform: translate(6px, 6px); box-shadow: 0 0 0 var(--ink); }
 .play-btn:focus-visible, .lobby-classic:focus-visible, .slot:focus-visible,
 .panel-close:focus-visible, .panel-btn:focus-visible, .chest-btn:focus-visible,
 .spot:focus-visible, .victory-close:focus-visible {
-  outline: 3px solid var(--gold); outline-offset: 3px;
+  outline: 3px solid var(--yellow); outline-offset: 3px;
 }
 
 .lobby-classic {
-  display: block; margin-top: 1.4rem; color: #dbe3ff;
+  display: block; margin-top: 1.4rem; color: #ffffff; opacity: .9;
   font-weight: 600; text-decoration: underline; text-underline-offset: 3px;
 }
 .lobby-tip {
   position: absolute; bottom: 1.2rem; left: 0; right: 0;
-  text-align: center; color: #dbe3ff; opacity: .85; font-size: .85rem; font-weight: 600;
+  text-align: center; color: #ffffff; opacity: .8; font-size: .85rem; font-weight: 600;
   padding: 0 1rem;
 }
 
 /* ============ GAME SHELL ============ */
-.game { position: fixed; inset: 0; background: #14202e; }
+/* letterbox color = the map's own ocean, so the square map sits seamlessly */
+.game { position: fixed; inset: 0; background: var(--ocean); }
 
-/* real map mode */
 .real-stage {
   position: absolute; inset: 0;
   display: grid; place-items: center;
@@ -117,9 +118,12 @@ body {
   position: absolute; inset: 0; width: 100%; height: 100%;
   pointer-events: none;
 }
-.storm-line {
-  fill: none; stroke: var(--storm); stroke-width: 14; opacity: .9;
+.map-grid path { stroke: #ffffff; stroke-opacity: .14; stroke-width: 3; fill: none; }
+.map-grid-text text {
+  font-family: Inter, sans-serif; font-weight: 800; font-size: 72px;
+  fill: #ffffff; fill-opacity: .5; text-anchor: middle;
 }
+.storm-line { fill: none; stroke: var(--storm); stroke-width: 14; opacity: .9; }
 #stormCircle.storm-line { stroke-width: 10; }
 
 /* POI hotspots on the real map */
@@ -132,25 +136,25 @@ body {
 }
 .spot-ring {
   width: 20px; height: 20px; border-radius: 50%;
-  background: var(--gold);
-  border: 4px solid #0b1530;
+  background: var(--yellow);
+  border: 4px solid var(--ink);
   box-shadow: 0 0 0 3px rgba(255, 255, 255, .85);
 }
 .spot-name {
   font-size: clamp(15px, 2.1vh, 24px);
   color: #ffffff;
   letter-spacing: .05em;
-  text-shadow: 2px 2px 0 #0b1530, -1px -1px 0 #0b1530, 1px -1px 0 #0b1530, -1px 1px 0 #0b1530;
+  text-shadow: 2px 2px 0 var(--ink), -1px -1px 0 var(--ink), 1px -1px 0 var(--ink), -1px 1px 0 var(--ink);
   white-space: nowrap;
 }
 .spot-tag {
   font-family: Inter, sans-serif; font-weight: 800;
-  font-size: clamp(9px, 1.2vh, 13px); letter-spacing: .3em; color: var(--gold);
-  text-shadow: 1px 1px 0 #0b1530, -1px -1px 0 #0b1530, 1px -1px 0 #0b1530, -1px 1px 0 #0b1530;
+  font-size: clamp(9px, 1.2vh, 13px); letter-spacing: .3em; color: var(--yellow);
+  text-shadow: 1px 1px 0 var(--ink), -1px -1px 0 var(--ink), 1px -1px 0 var(--ink), -1px 1px 0 var(--ink);
   white-space: nowrap;
 }
-.spot:hover .spot-ring, .spot:focus-visible .spot-ring { background: #fff; box-shadow: 0 0 0 3px var(--gold); }
-.spot:hover .spot-name { color: var(--gold); }
+.spot:hover .spot-ring, .spot:focus-visible .spot-ring { background: #fff; box-shadow: 0 0 0 3px var(--yellow); }
+.spot:hover .spot-name { color: var(--yellow); }
 .spot.visited .spot-ring { background: var(--uncommon); }
 .spot.visited .spot-name { color: var(--gold); }
 
@@ -165,13 +169,12 @@ body {
 }
 .compass {
   width: min(420px, 60vw); overflow: hidden;
-  border: 2px solid rgba(255,255,255,.35); border-radius: 4px;
-  background: rgba(11, 21, 48, .72);
-  mask-image: linear-gradient(90deg, transparent, black 20%, black 80%, transparent);
+  border: 2px solid rgba(255,255,255,.35); border-radius: 3px;
+  background: rgba(16, 20, 35, .72);
 }
 .compass-strip {
   display: flex; gap: 1.6rem; padding: .3rem 0; width: max-content;
-  font-weight: 800; font-size: .8rem; letter-spacing: .15em; color: #dbe3ff;
+  font-weight: 800; font-size: .8rem; letter-spacing: .15em; color: #ffffff;
   animation: compass 24s linear infinite;
 }
 @keyframes compass { to { transform: translateX(-50%); } }
@@ -183,8 +186,8 @@ body {
 .minimap {
   position: relative;
   width: clamp(110px, 14vw, 180px); aspect-ratio: 1;
-  border: 2px solid rgba(255,255,255,.4); border-radius: 4px; overflow: hidden;
-  background: #1f7ac9;
+  border: 2px solid rgba(255,255,255,.4); border-radius: 3px; overflow: hidden;
+  background: var(--ocean);
 }
 .minimap img, .minimap svg { position: absolute; inset: 0; width: 100%; height: 100%; display: block; object-fit: cover; }
 .mini-overlay { pointer-events: none; }
@@ -192,10 +195,10 @@ body {
 
 .hud-stats { display: flex; flex-direction: column; gap: .3rem; align-items: flex-end; }
 .hud-stat {
-  background: rgba(11, 21, 48, .78); border: 1px solid rgba(255,255,255,.22);
-  padding: .25rem .6rem; border-radius: 3px; font-size: .75rem; font-weight: 700; color: #dbe3ff;
+  background: rgba(16, 20, 35, .78); border: 1px solid rgba(255,255,255,.22);
+  padding: .25rem .6rem; border-radius: 3px; font-size: .75rem; font-weight: 700; color: #ffffff;
 }
-.hud-stat .ico { margin-right: .25rem; color: var(--gold); }
+.hud-stat .ico { margin-right: .25rem; color: var(--yellow); }
 
 .hud-vitals {
   position: absolute; left: .9rem; bottom: .9rem; z-index: 20;
@@ -203,11 +206,11 @@ body {
 }
 .bar {
   position: relative; height: 18px; border-radius: 3px; overflow: hidden;
-  background: rgba(11,21,48,.78); border: 1px solid rgba(255,255,255,.25);
+  background: rgba(16,20,35,.78); border: 1px solid rgba(255,255,255,.25);
 }
 .bar-fill { position: absolute; inset: 0; }
 .bar.shield .bar-fill { background: #35b6ff; }
-.bar.health .bar-fill { background: #52d95e; }
+.bar.health .bar-fill { background: #60d660; }
 .bar span {
   position: absolute; inset: 0; display: grid; place-items: center;
   font-size: .72rem; font-weight: 800; color: #06280f; letter-spacing: .06em;
@@ -221,23 +224,23 @@ body {
 .slot {
   width: clamp(52px, 7vw, 64px); aspect-ratio: 1;
   display: grid; place-items: center; align-content: center; gap: .2rem;
-  background: rgba(11,21,48,.78); border: 2px solid rgba(255,255,255,.28); border-radius: 4px;
-  text-decoration: none; color: #dbe3ff;
+  background: rgba(16,20,35,.78); border: 2px solid rgba(255,255,255,.28); border-radius: 3px;
+  text-decoration: none; color: #ffffff;
   transition: transform .12s ease, border-color .12s ease, background .12s ease;
 }
 .slot .ico { width: 1.3rem; height: 1.3rem; }
 .slot em { font-style: normal; font-size: .55rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
-.slot:hover { transform: translateY(-4px); border-color: var(--gold); color: #fff; background: rgba(30,42,90,.92); }
+.slot:hover { transform: translateY(-4px); border-color: var(--yellow); background: rgba(35,42,63,.92); }
 
 /* fan-content note */
 .fan-note {
   position: absolute; bottom: .15rem; left: 50%; transform: translateX(-50%);
   z-index: 20; margin: 0; padding: 0 1rem;
   max-width: 92vw; text-align: center;
-  font-size: .58rem; font-weight: 600; color: rgba(219, 227, 255, .55);
+  font-size: .58rem; font-weight: 600; color: rgba(255, 255, 255, .55);
   pointer-events: auto;
 }
-.fan-note a { color: rgba(219, 227, 255, .7); }
+.fan-note a { color: rgba(255, 255, 255, .7); }
 
 /* ============ FALLBACK MAP POIs ============ */
 .poi { cursor: pointer; outline: none; }
@@ -255,22 +258,22 @@ body {
 .poi-label {
   font-family: Anton, Inter, sans-serif;
   font-size: 30px; fill: #ffffff; text-anchor: middle;
-  paint-order: stroke; stroke: #0b1530; stroke-width: 7px; stroke-linejoin: round;
+  paint-order: stroke; stroke: #101423; stroke-width: 7px; stroke-linejoin: round;
   letter-spacing: .05em;
 }
 .poi-tag {
   font-family: Inter, sans-serif; font-weight: 800;
-  font-size: 15px; fill: var(--gold); text-anchor: middle; letter-spacing: .28em;
-  paint-order: stroke; stroke: #0b1530; stroke-width: 4px; stroke-linejoin: round;
+  font-size: 15px; fill: var(--yellow); text-anchor: middle; letter-spacing: .28em;
+  paint-order: stroke; stroke: #101423; stroke-width: 4px; stroke-linejoin: round;
 }
-.poi:hover .poi-label { fill: var(--gold); }
+.poi:hover .poi-label { fill: var(--yellow); }
 
 .storm { pointer-events: none; }
 
 /* ============ PANELS ============ */
 .panel-backdrop {
   position: fixed; inset: 0; z-index: 30;
-  background: rgba(5, 10, 28, .68);
+  background: rgba(6, 9, 18, .7);
 }
 .panel {
   position: fixed; z-index: 40;
@@ -281,7 +284,7 @@ body {
   background: var(--panel);
   border: 2px solid var(--line);
   clip-path: polygon(0 0, calc(100% - 22px) 0, 100% 22px, 100% 100%, 22px 100%, 0 calc(100% - 22px));
-  box-shadow: 10px 10px 0 rgba(5, 10, 28, .55);
+  box-shadow: 10px 10px 0 rgba(6, 9, 18, .55);
   animation: panel-in .28s cubic-bezier(.2, 1.4, .4, 1);
 }
 @keyframes panel-in {
@@ -293,18 +296,18 @@ body {
   display: flex; justify-content: space-between; align-items: flex-start;
   padding: 1.1rem 1.3rem .9rem;
   background: var(--panel-2);
-  border-bottom: 3px solid var(--gold);
+  border-bottom: 3px solid var(--yellow);
 }
-.panel-head h2 { margin: 0; font-size: clamp(1.5rem, 4vw, 2.2rem); transform: skewX(-4deg); text-shadow: 3px 3px 0 #0b1530; }
-.panel-head p { margin: .2rem 0 0; color: var(--gold); font-weight: 800; font-size: .72rem; letter-spacing: .3em; }
+.panel-head h2 { margin: 0; font-size: clamp(1.5rem, 4vw, 2.2rem); transform: skewX(-4deg); text-shadow: 3px 3px 0 var(--ink); }
+.panel-head p { margin: .2rem 0 0; color: var(--yellow); font-weight: 800; font-size: .72rem; letter-spacing: .3em; }
 .panel-close {
-  border: 2px solid rgba(255,255,255,.3); background: rgba(11,21,48,.6); color: var(--text);
+  border: 2px solid rgba(255,255,255,.3); background: rgba(16,20,35,.6); color: var(--text);
   width: 38px; height: 38px; border-radius: 3px; cursor: pointer;
   display: grid; place-items: center;
   transition: border-color .12s ease, color .12s ease;
 }
 .panel-close .ico { width: 1.1rem; height: 1.1rem; }
-.panel-close:hover { border-color: var(--gold); color: var(--gold); }
+.panel-close:hover { border-color: var(--yellow); color: var(--yellow); }
 
 .panel-body { padding: 1.1rem 1.3rem 1.4rem; overflow-y: auto; display: grid; gap: 1rem; }
 
@@ -314,9 +317,11 @@ body {
   background: var(--panel-2);
   border: 2px solid; border-radius: 2px;
 }
+.quest.mythic { border-color: var(--mythic); }
 .quest.legendary { border-color: var(--legendary); }
 .quest.epic { border-color: var(--epic); }
 .quest.rare { border-color: var(--rare); }
+.quest.uncommon { border-color: var(--uncommon); }
 
 .quest-top { display: flex; justify-content: space-between; align-items: center; gap: .8rem; flex-wrap: wrap; }
 .quest h3 { margin: 0; font-size: 1.05rem; }
@@ -331,15 +336,17 @@ body {
   clip-path: polygon(8% 0, 100% 0, 92% 100%, 0 100%);
   color: #1c1500; background: var(--gold);
 }
+.quest.mythic .rarity-pill { background: var(--mythic); color: #3a2b00; }
 .quest.legendary .rarity-pill, .loot.legendary .rarity-pill { background: var(--legendary); color: #2b1300; }
-.quest.epic .rarity-pill, .loot.epic .rarity-pill { background: var(--epic); color: #fff; }
-.quest.rare .rarity-pill { background: var(--rare); color: #04263f; }
+.quest.epic .rarity-pill, .loot.epic .rarity-pill { background: var(--epic); color: #2a0842; }
+.quest.rare .rarity-pill, .loot.rare .rarity-pill { background: var(--rare); color: #04263f; }
+.quest.uncommon .rarity-pill { background: var(--uncommon); color: #143001; }
 
 .xp-bar {
   position: relative; height: 22px; border-radius: 2px; overflow: hidden; margin-top: .8rem;
   background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.2);
 }
-.xp-fill { position: absolute; inset: 0; width: 94%; background: var(--gold); }
+.xp-fill { position: absolute; inset: 0; background: var(--gold); }
 .xp-bar span {
   position: absolute; inset: 0; display: grid; place-items: center;
   font-size: .68rem; font-weight: 800; letter-spacing: .18em; color: #1c1500;
@@ -355,13 +362,15 @@ body {
   transition: transform .15s ease;
 }
 .loot:hover { transform: translateY(-4px); }
-.loot.legendary { border-color: var(--legendary); box-shadow: 5px 5px 0 rgba(233, 141, 75, .25); }
-.loot.epic { border-color: var(--epic); box-shadow: 5px 5px 0 rgba(168, 85, 247, .22); }
+.loot.legendary { border-color: var(--legendary); box-shadow: 5px 5px 0 rgba(234, 141, 35, .3); }
+.loot.epic { border-color: var(--epic); box-shadow: 5px 5px 0 rgba(195, 89, 255, .25); }
+.loot.rare { border-color: var(--rare); box-shadow: 5px 5px 0 rgba(65, 191, 255, .25); }
 .loot .rarity-pill { align-self: flex-start; }
 .loot h3 { margin: .1rem 0 0; font-size: 1.02rem; }
 .loot p { margin: 0; color: var(--muted); font-size: .88rem; }
-.loot-stack { font-size: .74rem !important; font-weight: 700; letter-spacing: .04em; color: #cfd9ff !important; }
+.loot-stack { font-size: .74rem !important; font-weight: 700; letter-spacing: .04em; color: #dfe5f2 !important; }
 .loot .panel-btn { margin-top: auto; }
+.loot .panel-btn + .panel-btn { margin-top: .45rem; }
 
 .panel-btn {
   display: inline-flex; align-items: center; justify-content: center; gap: .45rem;
@@ -371,11 +380,18 @@ body {
   background: rgba(255,255,255,.07); border: 2px solid rgba(255,255,255,.3);
   transition: border-color .12s ease, background .12s ease;
 }
-.panel-btn:hover { border-color: var(--gold); background: rgba(255,255,255,.12); }
-.panel-btn.gold { background: var(--gold); color: #1c1500; border-color: var(--gold-deep); box-shadow: 3px 3px 0 rgba(5,10,28,.5); }
-.panel-btn.gold:hover { background: #ffdc4d; }
+.panel-btn:hover { border-color: var(--yellow); background: rgba(255,255,255,.12); }
+.panel-btn.gold { background: var(--yellow); color: #1c1500; border-color: var(--gold-deep); box-shadow: 3px 3px 0 rgba(6,9,18,.5); }
+.panel-btn.gold:hover { background: #fff75e; }
 
-/* inventory (skills) */
+/* inventory aisles (skills) */
+.aisle { display: grid; gap: .5rem; }
+.aisle-name { margin: 0; font-size: 1rem; letter-spacing: .08em; transform: skewX(-4deg); }
+.legendary-t { color: var(--legendary); }
+.epic-t { color: var(--epic); }
+.rare-t { color: var(--rare); }
+.uncommon-t { color: var(--uncommon); }
+
 .inv-grid { display: flex; flex-wrap: wrap; gap: .55rem; }
 .inv {
   padding: .5rem .85rem; border-radius: 2px; font-weight: 700; font-size: .88rem;
@@ -383,11 +399,11 @@ body {
   transition: transform .12s ease;
 }
 .inv:hover { transform: translateY(-3px); }
-.inv.legendary { border-color: var(--legendary); color: #ffc89a; }
-.inv.epic { border-color: var(--epic); color: #e3b8f7; }
-.inv.rare { border-color: var(--rare); color: #b5dcff; }
-.inv.uncommon { border-color: var(--uncommon); color: #c2f2c8; }
-.inv.common { border-color: var(--common); color: #dfe6ee; }
+.inv.legendary { border-color: var(--legendary); color: #ffc994; }
+.inv.epic { border-color: var(--epic); color: #e5bcff; }
+.inv.rare { border-color: var(--rare); color: #b9e4ff; }
+.inv.uncommon { border-color: var(--uncommon); color: #d0f5ac; }
+.inv.common { border-color: var(--common); color: #e3e3e3; }
 .inv-note { color: var(--muted); font-size: .8rem; margin: .4rem 0 0; }
 
 /* chest (contact) */
@@ -413,12 +429,12 @@ body {
 /* about */
 .about-card { display: flex; gap: 1.1rem; align-items: flex-start; flex-wrap: wrap; }
 .about-avatar {
-  flex: 0 0 auto; width: 92px; height: 92px; border-radius: 4px;
+  flex: 0 0 auto; width: 92px; height: 92px; border-radius: 3px;
   display: grid; place-items: center;
   font-family: Anton, Inter, sans-serif; font-size: 2rem;
-  background: var(--storm);
-  border: 3px solid var(--gold);
-  box-shadow: 5px 5px 0 rgba(5,10,28,.5);
+  background: var(--storm); color: #ffffff;
+  border: 3px solid var(--yellow);
+  box-shadow: 5px 5px 0 rgba(6,9,18,.5);
 }
 .about-card > div { flex: 1 1 260px; }
 .about-card h3 { margin: 0; font-size: 1.3rem; }
@@ -426,7 +442,7 @@ body {
 
 .stat-rows { display: grid; gap: .5rem; margin-top: .8rem; }
 .stat-row { display: grid; grid-template-columns: 130px 1fr auto; gap: .6rem; align-items: center; }
-.stat-row span { font-size: .68rem; font-weight: 800; letter-spacing: .14em; color: #cfd9ff; }
+.stat-row span { font-size: .68rem; font-weight: 800; letter-spacing: .14em; color: #dfe5f2; }
 .stat-row em { font-size: .7rem; color: var(--muted); }
 .stat-bar { height: 10px; border-radius: 2px; background: rgba(255,255,255,.1); overflow: hidden; }
 .stat-bar i { display: block; height: 100%; background: #35b6ff; }
@@ -434,24 +450,24 @@ body {
 /* ============ VICTORY ============ */
 .victory {
   position: fixed; inset: 0; z-index: 50; display: grid; place-items: center;
-  background: rgba(5, 10, 28, .78);
+  background: rgba(6, 9, 18, .8);
 }
 .victory-inner {
   text-align: center; padding: 2.4rem 2rem;
   animation: panel-in .4s cubic-bezier(.2, 1.4, .4, 1);
 }
-.victory-hash { margin: 0; font-size: clamp(2rem, 6vw, 3.4rem); color: var(--gold); text-shadow: 3px 3px 0 #0b1530; }
+.victory-hash { margin: 0; font-size: clamp(2rem, 6vw, 3.4rem); color: var(--gold); text-shadow: 3px 3px 0 var(--ink); }
 .victory-title {
   margin: 0; font-size: clamp(3rem, 10vw, 6.4rem); line-height: 1;
   transform: skewX(-6deg);
   color: var(--gold);
-  text-shadow: 6px 6px 0 #0b1530;
+  text-shadow: 6px 6px 0 var(--ink);
 }
-.victory-sub { color: #dbe3ff; font-weight: 700; margin: 1rem 0 1.6rem; }
+.victory-sub { color: #ffffff; font-weight: 700; margin: 1rem 0 1.6rem; }
 .victory .panel-btn.gold { font-size: 1rem; padding: .8rem 1.4rem; }
 .victory-close {
   display: block; margin: 1.2rem auto 0; background: none; border: none; cursor: pointer;
-  color: #cfd9ff; font-weight: 700; text-decoration: underline; text-underline-offset: 3px; font-size: .85rem;
+  color: #dfe5f2; font-weight: 700; text-decoration: underline; text-underline-offset: 3px; font-size: .85rem;
 }
 
 .confetti {

--- a/fortnite/styles.css
+++ b/fortnite/styles.css
@@ -1,0 +1,403 @@
+:root {
+  --ink: #0b1530;
+  --panel: #16204a;
+  --panel-2: #1d2a5e;
+  --text: #f5f7ff;
+  --muted: #aab6e0;
+  --gold: #ffd54d;
+  --legendary: #ff9d2e;
+  --epic: #b44ee8;
+  --rare: #3fa9ff;
+  --uncommon: #52d95e;
+  --common: #b8c2cf;
+  --storm: #7b2ff7;
+}
+
+* { box-sizing: border-box; }
+[hidden] { display: none !important; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, sans-serif;
+  background: var(--ink);
+  color: var(--text);
+  overflow: hidden;
+}
+
+.fn-font, .lobby-title, .play-btn span, .poi-label, .panel-head h2,
+.victory-title, .victory-hash, .rarity-pill, .lobby-eyebrow {
+  font-family: Anton, Inter, sans-serif;
+  letter-spacing: 0.04em;
+}
+
+/* ============ LOBBY ============ */
+.lobby {
+  position: fixed; inset: 0; z-index: 60;
+  display: grid; place-items: center;
+  overflow: hidden;
+  transition: opacity .5s ease, transform .5s ease;
+}
+.lobby.leaving { opacity: 0; transform: scale(1.06); pointer-events: none; }
+.lobby-sky {
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(circle at 75% 20%, rgba(255, 213, 77, .25), transparent 40%),
+    linear-gradient(160deg, #2b1a6b 0%, #4a2fb8 35%, #7b2ff7 70%, #b44ee8 100%);
+}
+.lobby-sky::after {
+  content: "";
+  position: absolute; inset: -50%;
+  background: repeating-conic-gradient(from 0deg, rgba(255,255,255,.06) 0deg 6deg, transparent 6deg 18deg);
+  animation: rays 60s linear infinite;
+}
+@keyframes rays { to { transform: rotate(360deg); } }
+
+.lobby-content { position: relative; text-align: center; padding: 1rem; }
+.lobby-eyebrow { color: var(--gold); font-size: clamp(.85rem, 2vw, 1.1rem); margin: 0 0 .4rem; }
+.lobby-title {
+  font-size: clamp(3.4rem, 12vw, 8rem);
+  line-height: .92; margin: 0;
+  transform: skewX(-6deg);
+  text-shadow: 0 6px 0 rgba(0,0,0,.28), 0 0 40px rgba(255,255,255,.25);
+}
+.lobby-sub { color: #e8ddff; font-weight: 700; margin: 1rem 0 2rem; font-size: clamp(.8rem, 2vw, 1rem); letter-spacing: .12em; }
+
+.play-btn {
+  cursor: pointer; border: none;
+  background: linear-gradient(180deg, #ffe066, #ffb347);
+  color: #3a2500;
+  padding: 1rem 3.4rem;
+  clip-path: polygon(6% 0, 100% 0, 94% 100%, 0 100%);
+  box-shadow: 0 8px 0 #a86a00, 0 14px 30px rgba(0,0,0,.35);
+  transition: transform .12s ease, box-shadow .12s ease;
+}
+.play-btn span { font-size: clamp(1.6rem, 4vw, 2.4rem); }
+.play-btn:hover { transform: translateY(2px) scale(1.02); box-shadow: 0 6px 0 #a86a00, 0 10px 24px rgba(0,0,0,.35); }
+.play-btn:active { transform: translateY(6px); box-shadow: 0 2px 0 #a86a00; }
+
+.lobby-classic {
+  display: block; margin-top: 1.4rem; color: #e8ddff; opacity: .85;
+  font-weight: 600; text-decoration: underline; text-underline-offset: 3px;
+}
+.lobby-tip {
+  position: absolute; bottom: 1.2rem; left: 0; right: 0;
+  text-align: center; color: #e8ddff; opacity: .8; font-size: .85rem; font-weight: 600;
+  padding: 0 1rem;
+}
+
+/* ============ GAME SHELL ============ */
+.game { position: fixed; inset: 0; }
+
+.map-wrap { position: absolute; inset: 0; }
+#mapSvg { width: 100%; height: 100%; display: block; }
+
+/* ============ HUD ============ */
+.hud-top {
+  position: absolute; top: .8rem; left: 50%; transform: translateX(-50%);
+  z-index: 20; pointer-events: none;
+}
+.compass {
+  width: min(420px, 60vw); overflow: hidden;
+  border: 2px solid rgba(255,255,255,.35); border-radius: 4px;
+  background: rgba(11, 21, 48, .55); backdrop-filter: blur(4px);
+  mask-image: linear-gradient(90deg, transparent, black 20%, black 80%, transparent);
+}
+.compass-strip {
+  display: flex; gap: 1.6rem; padding: .3rem 0; width: max-content;
+  font-weight: 800; font-size: .8rem; letter-spacing: .15em; color: #dbe3ff;
+  animation: compass 24s linear infinite;
+}
+@keyframes compass { to { transform: translateX(-50%); } }
+
+.hud-right {
+  position: absolute; top: .8rem; right: .8rem; z-index: 20;
+  display: flex; flex-direction: column; gap: .5rem; align-items: flex-end;
+}
+.minimap {
+  width: clamp(110px, 14vw, 180px); aspect-ratio: 1;
+  border: 2px solid rgba(255,255,255,.4); border-radius: 6px; overflow: hidden;
+  box-shadow: 0 6px 18px rgba(0,0,0,.4);
+}
+.minimap svg { width: 100%; height: 100%; display: block; }
+.storm-ring { fill: none; stroke: var(--storm); stroke-width: 26; opacity: .9; }
+
+.hud-stats { display: flex; flex-direction: column; gap: .3rem; align-items: flex-end; }
+.hud-stat {
+  background: rgba(11, 21, 48, .65); border: 1px solid rgba(255,255,255,.22);
+  padding: .25rem .6rem; border-radius: 4px; font-size: .75rem; font-weight: 700; color: #dbe3ff;
+  backdrop-filter: blur(4px);
+}
+.hud-ico { margin-right: .25rem; }
+
+.hud-vitals {
+  position: absolute; left: .9rem; bottom: .9rem; z-index: 20;
+  display: flex; flex-direction: column; gap: .35rem; width: min(300px, 42vw);
+}
+.bar {
+  position: relative; height: 18px; border-radius: 4px; overflow: hidden;
+  background: rgba(11,21,48,.7); border: 1px solid rgba(255,255,255,.25);
+}
+.bar-fill { position: absolute; inset: 0; }
+.bar.shield .bar-fill { background: linear-gradient(90deg, #35b6ff, #7ad9ff); }
+.bar.health .bar-fill { background: linear-gradient(90deg, #3ed95e, #9dff6e); }
+.bar span {
+  position: absolute; inset: 0; display: grid; place-items: center;
+  font-size: .72rem; font-weight: 800; color: #06280f; letter-spacing: .06em;
+}
+.bar.shield span { color: #032c47; }
+
+.hotbar {
+  position: absolute; right: .9rem; bottom: .9rem; z-index: 20;
+  display: flex; gap: .45rem;
+}
+.slot {
+  width: clamp(52px, 7vw, 64px); aspect-ratio: 1;
+  display: grid; place-items: center; gap: 0;
+  background: rgba(11,21,48,.7); border: 2px solid rgba(255,255,255,.28); border-radius: 8px;
+  text-decoration: none; font-size: 1.3rem;
+  transition: transform .12s ease, border-color .12s ease, background .12s ease;
+}
+.slot em { font-style: normal; font-size: .55rem; font-weight: 800; color: #dbe3ff; letter-spacing: .08em; text-transform: uppercase; }
+.slot:hover { transform: translateY(-4px); border-color: var(--gold); background: rgba(30,42,90,.85); }
+
+/* ============ MAP / POIs ============ */
+.poi { cursor: pointer; outline: none; }
+.poi-hit {
+  fill: #ffffff; fill-opacity: 0; stroke: #ffffff; stroke-opacity: 0;
+  stroke-width: 4; stroke-dasharray: 14 10;
+  transition: fill-opacity .15s ease, stroke-opacity .15s ease;
+}
+.poi:hover .poi-hit, .poi:focus-visible .poi-hit { fill-opacity: .12; stroke-opacity: .85; animation: spin-dash 12s linear infinite; }
+@keyframes spin-dash { to { stroke-dashoffset: -240; } }
+
+.poi.visited .poi-hit { stroke: var(--gold); stroke-opacity: .5; }
+.poi.visited .poi-label { fill: var(--gold); }
+
+.poi-label {
+  font-family: Anton, Inter, sans-serif;
+  font-size: 30px; fill: #ffffff; text-anchor: middle;
+  paint-order: stroke; stroke: #0b1530; stroke-width: 7px; stroke-linejoin: round;
+  letter-spacing: .05em;
+}
+.poi-tag {
+  font-family: Inter, sans-serif; font-weight: 800;
+  font-size: 15px; fill: var(--gold); text-anchor: middle; letter-spacing: .28em;
+  paint-order: stroke; stroke: #0b1530; stroke-width: 4px; stroke-linejoin: round;
+}
+.poi:hover .poi-label { fill: var(--gold); }
+
+.storm { pointer-events: none; }
+#stormCircle { filter: drop-shadow(0 0 14px rgba(123, 47, 247, .8)); }
+
+.battle-bus { pointer-events: none; opacity: 0; }
+.battle-bus.flying { opacity: 1; }
+
+/* ============ PANELS ============ */
+.panel-backdrop {
+  position: fixed; inset: 0; z-index: 30;
+  background: rgba(5, 10, 28, .6); backdrop-filter: blur(3px);
+}
+.panel {
+  position: fixed; z-index: 40;
+  top: 50%; left: 50%; transform: translate(-50%, -50%);
+  width: min(860px, calc(100vw - 1.6rem));
+  max-height: min(84vh, 900px);
+  display: flex; flex-direction: column;
+  background: linear-gradient(170deg, var(--panel-2), var(--panel) 55%, #101a3e);
+  border: 2px solid rgba(255,255,255,.18);
+  border-radius: 10px;
+  box-shadow: 0 30px 80px rgba(0,0,0,.6), 0 0 0 6px rgba(123,47,247,.12);
+  animation: panel-in .28s cubic-bezier(.2, 1.4, .4, 1);
+}
+@keyframes panel-in {
+  from { transform: translate(-50%, -46%) scale(.92); opacity: 0; }
+  to { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+}
+
+.panel-head {
+  display: flex; justify-content: space-between; align-items: flex-start;
+  padding: 1.1rem 1.3rem .9rem;
+  background: linear-gradient(90deg, rgba(123,47,247,.35), transparent 65%);
+  border-bottom: 2px solid rgba(255,255,255,.12);
+  border-radius: 8px 8px 0 0;
+}
+.panel-head h2 { margin: 0; font-size: clamp(1.5rem, 4vw, 2.2rem); transform: skewX(-4deg); }
+.panel-head p { margin: .2rem 0 0; color: var(--gold); font-weight: 800; font-size: .72rem; letter-spacing: .3em; }
+.panel-close {
+  border: 2px solid rgba(255,255,255,.3); background: rgba(11,21,48,.6); color: var(--text);
+  width: 38px; height: 38px; border-radius: 8px; cursor: pointer; font-size: 1rem; font-weight: 800;
+  transition: border-color .12s ease, transform .12s ease;
+}
+.panel-close:hover { border-color: var(--gold); transform: rotate(90deg); }
+
+.panel-body { padding: 1.1rem 1.3rem 1.4rem; overflow-y: auto; display: grid; gap: 1rem; }
+
+/* quests (experience/education) */
+.quest {
+  border-radius: 10px; padding: 1rem 1.1rem;
+  background: rgba(11, 21, 48, .55);
+  border: 2px solid; border-image: none;
+}
+.quest.legendary { border-color: var(--legendary); box-shadow: inset 0 0 40px rgba(255,157,46,.08); }
+.quest.epic { border-color: var(--epic); box-shadow: inset 0 0 40px rgba(180,78,232,.08); }
+.quest.rare { border-color: var(--rare); box-shadow: inset 0 0 40px rgba(63,169,255,.08); }
+
+.quest-top { display: flex; justify-content: space-between; align-items: center; gap: .8rem; flex-wrap: wrap; }
+.quest h3 { margin: 0; font-size: 1.05rem; }
+.quest-meta { color: var(--muted); margin: .25rem 0 .6rem; font-size: .85rem; }
+.quest-list { list-style: none; margin: 0; padding: 0; display: grid; gap: .5rem; }
+.quest-list li { display: block; font-size: .92rem; line-height: 1.45; }
+.check { color: var(--uncommon); font-weight: 800; margin-right: .4rem; }
+.xp { color: var(--gold); font-weight: 800; white-space: nowrap; margin-left: .3rem; }
+
+.rarity-pill {
+  font-size: .68rem; letter-spacing: .16em; padding: .28rem .6rem; border-radius: 4px; color: #1a1200;
+  background: linear-gradient(180deg, #ffe066, #ffb347);
+}
+.quest.epic .rarity-pill, .loot.epic .rarity-pill { background: linear-gradient(180deg, #d98aff, var(--epic)); color: #24063a; }
+.quest.rare .rarity-pill { background: linear-gradient(180deg, #8fd0ff, var(--rare)); color: #04263f; }
+
+.xp-bar {
+  position: relative; height: 22px; border-radius: 5px; overflow: hidden; margin-top: .8rem;
+  background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.2);
+}
+.xp-fill { position: absolute; inset: 0; width: 94%; background: linear-gradient(90deg, #ffb347, var(--gold)); }
+.xp-bar span {
+  position: absolute; inset: 0; display: grid; place-items: center;
+  font-size: .68rem; font-weight: 800; letter-spacing: .18em; color: #2d1c00;
+}
+
+/* loot (projects) */
+.loot-grid { grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); align-items: stretch; }
+.loot {
+  display: flex; flex-direction: column; gap: .5rem;
+  border-radius: 10px; padding: 1rem 1.1rem;
+  background: rgba(11, 21, 48, .55);
+  border: 2px solid;
+  transition: transform .15s ease, box-shadow .15s ease;
+}
+.loot:hover { transform: translateY(-4px); }
+.loot.legendary { border-color: var(--legendary); box-shadow: 0 0 24px rgba(255,157,46,.25); }
+.loot.epic { border-color: var(--epic); box-shadow: 0 0 24px rgba(180,78,232,.2); }
+.loot .rarity-pill { align-self: flex-start; }
+.loot h3 { margin: .1rem 0 0; font-size: 1.02rem; }
+.loot p { margin: 0; color: var(--muted); font-size: .88rem; }
+.loot-stack { font-size: .74rem !important; font-weight: 700; letter-spacing: .04em; color: #cfd9ff !important; }
+.loot .panel-btn { margin-top: auto; }
+
+.panel-btn {
+  display: inline-block; text-align: center; text-decoration: none; cursor: pointer;
+  font-weight: 800; font-size: .82rem; letter-spacing: .08em;
+  color: var(--text); padding: .6rem .9rem; border-radius: 6px;
+  background: rgba(255,255,255,.08); border: 2px solid rgba(255,255,255,.25);
+  transition: border-color .12s ease, background .12s ease;
+}
+.panel-btn:hover { border-color: var(--gold); background: rgba(255,255,255,.14); }
+.panel-btn.gold { background: linear-gradient(180deg, #ffe066, #ffb347); color: #3a2500; border-color: transparent; }
+.panel-btn.gold:hover { filter: brightness(1.06); }
+
+/* inventory (skills) */
+.inv-grid { display: flex; flex-wrap: wrap; gap: .55rem; }
+.inv {
+  padding: .5rem .85rem; border-radius: 6px; font-weight: 700; font-size: .88rem;
+  border: 2px solid; background: rgba(11,21,48,.6);
+  transition: transform .12s ease;
+}
+.inv:hover { transform: translateY(-3px) scale(1.04); }
+.inv.legendary { border-color: var(--legendary); color: #ffcf9a; box-shadow: 0 0 14px rgba(255,157,46,.35); }
+.inv.epic { border-color: var(--epic); color: #e3b8f7; }
+.inv.rare { border-color: var(--rare); color: #b5dcff; }
+.inv.uncommon { border-color: var(--uncommon); color: #c2f2c8; }
+.inv.common { border-color: var(--common); color: #dfe6ee; }
+.inv-note { color: var(--muted); font-size: .8rem; margin: .4rem 0 0; }
+
+/* chest (contact) */
+.chest-zone { display: grid; place-items: center; padding: 1rem 0 .5rem; }
+.chest-btn {
+  display: grid; place-items: center; gap: .4rem;
+  background: none; border: none; cursor: pointer; color: var(--gold);
+  font-family: Anton, Inter, sans-serif; font-size: 1rem; letter-spacing: .2em;
+  animation: chest-bob 2.2s ease-in-out infinite;
+  filter: drop-shadow(0 0 18px rgba(255, 213, 77, .45));
+  transition: transform .15s ease;
+}
+.chest-btn:hover { transform: scale(1.06); }
+@keyframes chest-bob { 0%, 100% { translate: 0 0; } 50% { translate: 0 -8px; } }
+
+.chest-loot { display: grid; gap: .6rem; justify-items: stretch; width: min(420px, 100%); animation: loot-pop .35s cubic-bezier(.2, 1.4, .4, 1); }
+@keyframes loot-pop {
+  from { transform: scale(.88); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+.chest-loot .panel-btn { font-size: .92rem; }
+.chest-note { text-align: center; color: var(--muted); font-size: .8rem; margin: .2rem 0 0; }
+
+/* about */
+.about-card { display: flex; gap: 1.1rem; align-items: flex-start; flex-wrap: wrap; }
+.about-avatar {
+  flex: 0 0 auto; width: 92px; height: 92px; border-radius: 12px;
+  display: grid; place-items: center;
+  font-family: Anton, Inter, sans-serif; font-size: 2rem;
+  background: linear-gradient(160deg, #7b2ff7, #b44ee8);
+  border: 3px solid var(--gold);
+  box-shadow: 0 0 24px rgba(180,78,232,.5);
+}
+.about-card > div { flex: 1 1 260px; }
+.about-card h3 { margin: 0; font-size: 1.3rem; }
+.about-blurb { color: var(--muted); font-size: .92rem; line-height: 1.55; }
+
+.stat-rows { display: grid; gap: .5rem; margin-top: .8rem; }
+.stat-row { display: grid; grid-template-columns: 130px 1fr auto; gap: .6rem; align-items: center; }
+.stat-row span { font-size: .68rem; font-weight: 800; letter-spacing: .14em; color: #cfd9ff; }
+.stat-row em { font-size: .7rem; color: var(--muted); }
+.stat-bar { height: 10px; border-radius: 99px; background: rgba(255,255,255,.1); overflow: hidden; }
+.stat-bar i { display: block; height: 100%; border-radius: 99px; background: linear-gradient(90deg, #35b6ff, #9dff6e); }
+
+/* ============ VICTORY ============ */
+.victory {
+  position: fixed; inset: 0; z-index: 50; display: grid; place-items: center;
+  background: rgba(5, 10, 28, .72); backdrop-filter: blur(4px);
+}
+.victory-inner {
+  text-align: center; padding: 2.4rem 2rem;
+  animation: panel-in .4s cubic-bezier(.2, 1.4, .4, 1);
+}
+.victory-hash { margin: 0; font-size: clamp(2rem, 6vw, 3.4rem); color: var(--gold); text-shadow: 0 4px 0 rgba(0,0,0,.35); }
+.victory-title {
+  margin: 0; font-size: clamp(3rem, 10vw, 6.4rem); line-height: 1;
+  transform: skewX(-6deg);
+  background: linear-gradient(180deg, #fff6c9, var(--gold) 55%, #ffb347);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+  filter: drop-shadow(0 6px 0 rgba(0,0,0,.35));
+}
+.victory-sub { color: #e8ddff; font-weight: 700; margin: 1rem 0 1.6rem; }
+.victory .panel-btn.gold { font-size: 1rem; padding: .8rem 1.4rem; }
+.victory-close {
+  display: block; margin: 1.2rem auto 0; background: none; border: none; cursor: pointer;
+  color: #cfd9ff; font-weight: 700; text-decoration: underline; text-underline-offset: 3px; font-size: .85rem;
+}
+
+.confetti {
+  position: fixed; top: -20px; z-index: 55; width: 10px; height: 16px;
+  animation: confetti-fall linear forwards; pointer-events: none;
+}
+@keyframes confetti-fall {
+  to { transform: translateY(110vh) rotate(720deg); }
+}
+
+/* ============ RESPONSIVE ============ */
+@media (max-width: 720px) {
+  .hud-vitals { width: 40vw; }
+  .bar { height: 14px; }
+  .hotbar { gap: .3rem; }
+  .compass { display: none; }
+  .hud-stat:first-child { display: none; }
+  .panel { max-height: 90vh; }
+  .poi-label { font-size: 40px; }
+  .poi-tag { font-size: 22px; }
+  .stat-row { grid-template-columns: 100px 1fr auto; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lobby-sky::after, .compass-strip, .chest-btn { animation: none; }
+}

--- a/fortnite/styles.css
+++ b/fortnite/styles.css
@@ -1,16 +1,18 @@
 :root {
   --ink: #0b1530;
-  --panel: #16204a;
-  --panel-2: #1d2a5e;
+  --panel: #141d45;
+  --panel-2: #1b2657;
+  --line: #3c4a86;
   --text: #f5f7ff;
   --muted: #aab6e0;
-  --gold: #ffd54d;
-  --legendary: #ff9d2e;
-  --epic: #b44ee8;
-  --rare: #3fa9ff;
-  --uncommon: #52d95e;
-  --common: #b8c2cf;
-  --storm: #7b2ff7;
+  --gold: #ffd21f;
+  --gold-deep: #c99a00;
+  --legendary: #e98d4b;
+  --epic: #a855f7;
+  --rare: #37a5ff;
+  --uncommon: #60aa3a;
+  --common: #b1b1b1;
+  --storm: #8547e8;
 }
 
 * { box-sizing: border-box; }
@@ -24,11 +26,14 @@ body {
   overflow: hidden;
 }
 
-.fn-font, .lobby-title, .play-btn span, .poi-label, .panel-head h2,
-.victory-title, .victory-hash, .rarity-pill, .lobby-eyebrow {
+.lobby-title, .play-btn span, .poi-label, .panel-head h2,
+.victory-title, .victory-hash, .rarity-pill, .lobby-eyebrow,
+.spot-name, .chest-btn span {
   font-family: Anton, Inter, sans-serif;
   letter-spacing: 0.04em;
 }
+
+.ico { width: 1.05em; height: 1.05em; vertical-align: -0.18em; }
 
 /* ============ LOBBY ============ */
 .lobby {
@@ -38,56 +43,118 @@ body {
   transition: opacity .5s ease, transform .5s ease;
 }
 .lobby.leaving { opacity: 0; transform: scale(1.06); pointer-events: none; }
+/* flat royal blue with hard-edged diagonal stripes, like the Ch1 lobby */
 .lobby-sky {
   position: absolute; inset: 0;
-  background:
-    radial-gradient(circle at 75% 20%, rgba(255, 213, 77, .25), transparent 40%),
-    linear-gradient(160deg, #2b1a6b 0%, #4a2fb8 35%, #7b2ff7 70%, #b44ee8 100%);
+  background: #2440b8;
 }
 .lobby-sky::after {
   content: "";
-  position: absolute; inset: -50%;
-  background: repeating-conic-gradient(from 0deg, rgba(255,255,255,.06) 0deg 6deg, transparent 6deg 18deg);
-  animation: rays 60s linear infinite;
+  position: absolute; inset: 0;
+  background: repeating-linear-gradient(
+    115deg,
+    transparent 0 90px,
+    #1f39a6 90px 180px
+  );
 }
-@keyframes rays { to { transform: rotate(360deg); } }
-
 .lobby-content { position: relative; text-align: center; padding: 1rem; }
-.lobby-eyebrow { color: var(--gold); font-size: clamp(.85rem, 2vw, 1.1rem); margin: 0 0 .4rem; }
+.lobby-eyebrow { color: var(--gold); font-size: clamp(.95rem, 2vw, 1.2rem); margin: 0 0 .4rem; letter-spacing: .1em; }
 .lobby-title {
   font-size: clamp(3.4rem, 12vw, 8rem);
   line-height: .92; margin: 0;
   transform: skewX(-6deg);
-  text-shadow: 0 6px 0 rgba(0,0,0,.28), 0 0 40px rgba(255,255,255,.25);
+  color: #ffffff;
+  text-shadow: 5px 5px 0 #0b1530;
 }
-.lobby-sub { color: #e8ddff; font-weight: 700; margin: 1rem 0 2rem; font-size: clamp(.8rem, 2vw, 1rem); letter-spacing: .12em; }
+.lobby-sub { color: #dbe3ff; font-weight: 700; margin: 1rem 0 2rem; font-size: clamp(.8rem, 2vw, 1rem); letter-spacing: .12em; }
 
 .play-btn {
   cursor: pointer; border: none;
-  background: linear-gradient(180deg, #ffe066, #ffb347);
-  color: #3a2500;
+  background: var(--gold);
+  color: #1c1500;
   padding: 1rem 3.4rem;
   clip-path: polygon(6% 0, 100% 0, 94% 100%, 0 100%);
-  box-shadow: 0 8px 0 #a86a00, 0 14px 30px rgba(0,0,0,.35);
+  box-shadow: 6px 6px 0 #0b1530;
   transition: transform .12s ease, box-shadow .12s ease;
 }
-.play-btn span { font-size: clamp(1.6rem, 4vw, 2.4rem); }
-.play-btn:hover { transform: translateY(2px) scale(1.02); box-shadow: 0 6px 0 #a86a00, 0 10px 24px rgba(0,0,0,.35); }
-.play-btn:active { transform: translateY(6px); box-shadow: 0 2px 0 #a86a00; }
+.play-btn span { font-size: clamp(1.6rem, 4vw, 2.4rem); transform: skewX(-6deg); display: inline-block; }
+.play-btn:hover { transform: translate(2px, 2px); box-shadow: 4px 4px 0 #0b1530; background: #ffdc4d; }
+.play-btn:active { transform: translate(6px, 6px); box-shadow: 0 0 0 #0b1530; }
+.play-btn:focus-visible, .lobby-classic:focus-visible, .slot:focus-visible,
+.panel-close:focus-visible, .panel-btn:focus-visible, .chest-btn:focus-visible,
+.spot:focus-visible, .victory-close:focus-visible {
+  outline: 3px solid var(--gold); outline-offset: 3px;
+}
 
 .lobby-classic {
-  display: block; margin-top: 1.4rem; color: #e8ddff; opacity: .85;
+  display: block; margin-top: 1.4rem; color: #dbe3ff;
   font-weight: 600; text-decoration: underline; text-underline-offset: 3px;
 }
 .lobby-tip {
   position: absolute; bottom: 1.2rem; left: 0; right: 0;
-  text-align: center; color: #e8ddff; opacity: .8; font-size: .85rem; font-weight: 600;
+  text-align: center; color: #dbe3ff; opacity: .85; font-size: .85rem; font-weight: 600;
   padding: 0 1rem;
 }
 
 /* ============ GAME SHELL ============ */
-.game { position: fixed; inset: 0; }
+.game { position: fixed; inset: 0; background: #14202e; }
 
+/* real map mode */
+.real-stage {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+}
+.map-box {
+  position: relative;
+  height: 100vh; width: 100vh;
+  max-width: 100vw; max-height: 100vw;
+}
+.map-box img {
+  width: 100%; height: 100%; display: block;
+  user-select: none; -webkit-user-drag: none;
+}
+.map-overlay {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+  pointer-events: none;
+}
+.storm-line {
+  fill: none; stroke: var(--storm); stroke-width: 14; opacity: .9;
+}
+#stormCircle.storm-line { stroke-width: 10; }
+
+/* POI hotspots on the real map */
+.spot {
+  position: absolute; left: var(--x); top: var(--y);
+  transform: translate(-50%, -50%);
+  display: grid; justify-items: center; gap: .1rem;
+  background: none; border: none; cursor: pointer; padding: .4rem;
+  color: #fff;
+}
+.spot-ring {
+  width: 20px; height: 20px; border-radius: 50%;
+  background: var(--gold);
+  border: 4px solid #0b1530;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, .85);
+}
+.spot-name {
+  font-size: clamp(15px, 2.1vh, 24px);
+  color: #ffffff;
+  letter-spacing: .05em;
+  text-shadow: 2px 2px 0 #0b1530, -1px -1px 0 #0b1530, 1px -1px 0 #0b1530, -1px 1px 0 #0b1530;
+  white-space: nowrap;
+}
+.spot-tag {
+  font-family: Inter, sans-serif; font-weight: 800;
+  font-size: clamp(9px, 1.2vh, 13px); letter-spacing: .3em; color: var(--gold);
+  text-shadow: 1px 1px 0 #0b1530, -1px -1px 0 #0b1530, 1px -1px 0 #0b1530, -1px 1px 0 #0b1530;
+  white-space: nowrap;
+}
+.spot:hover .spot-ring, .spot:focus-visible .spot-ring { background: #fff; box-shadow: 0 0 0 3px var(--gold); }
+.spot:hover .spot-name { color: var(--gold); }
+.spot.visited .spot-ring { background: var(--uncommon); }
+.spot.visited .spot-name { color: var(--gold); }
+
+/* fallback map mode */
 .map-wrap { position: absolute; inset: 0; }
 #mapSvg { width: 100%; height: 100%; display: block; }
 
@@ -99,7 +166,7 @@ body {
 .compass {
   width: min(420px, 60vw); overflow: hidden;
   border: 2px solid rgba(255,255,255,.35); border-radius: 4px;
-  background: rgba(11, 21, 48, .55); backdrop-filter: blur(4px);
+  background: rgba(11, 21, 48, .72);
   mask-image: linear-gradient(90deg, transparent, black 20%, black 80%, transparent);
 }
 .compass-strip {
@@ -114,32 +181,33 @@ body {
   display: flex; flex-direction: column; gap: .5rem; align-items: flex-end;
 }
 .minimap {
+  position: relative;
   width: clamp(110px, 14vw, 180px); aspect-ratio: 1;
-  border: 2px solid rgba(255,255,255,.4); border-radius: 6px; overflow: hidden;
-  box-shadow: 0 6px 18px rgba(0,0,0,.4);
+  border: 2px solid rgba(255,255,255,.4); border-radius: 4px; overflow: hidden;
+  background: #1f7ac9;
 }
-.minimap svg { width: 100%; height: 100%; display: block; }
-.storm-ring { fill: none; stroke: var(--storm); stroke-width: 26; opacity: .9; }
+.minimap img, .minimap svg { position: absolute; inset: 0; width: 100%; height: 100%; display: block; object-fit: cover; }
+.mini-overlay { pointer-events: none; }
+#miniStorm { fill: none; stroke: var(--storm); stroke-width: 3; opacity: .95; }
 
 .hud-stats { display: flex; flex-direction: column; gap: .3rem; align-items: flex-end; }
 .hud-stat {
-  background: rgba(11, 21, 48, .65); border: 1px solid rgba(255,255,255,.22);
-  padding: .25rem .6rem; border-radius: 4px; font-size: .75rem; font-weight: 700; color: #dbe3ff;
-  backdrop-filter: blur(4px);
+  background: rgba(11, 21, 48, .78); border: 1px solid rgba(255,255,255,.22);
+  padding: .25rem .6rem; border-radius: 3px; font-size: .75rem; font-weight: 700; color: #dbe3ff;
 }
-.hud-ico { margin-right: .25rem; }
+.hud-stat .ico { margin-right: .25rem; color: var(--gold); }
 
 .hud-vitals {
   position: absolute; left: .9rem; bottom: .9rem; z-index: 20;
   display: flex; flex-direction: column; gap: .35rem; width: min(300px, 42vw);
 }
 .bar {
-  position: relative; height: 18px; border-radius: 4px; overflow: hidden;
-  background: rgba(11,21,48,.7); border: 1px solid rgba(255,255,255,.25);
+  position: relative; height: 18px; border-radius: 3px; overflow: hidden;
+  background: rgba(11,21,48,.78); border: 1px solid rgba(255,255,255,.25);
 }
 .bar-fill { position: absolute; inset: 0; }
-.bar.shield .bar-fill { background: linear-gradient(90deg, #35b6ff, #7ad9ff); }
-.bar.health .bar-fill { background: linear-gradient(90deg, #3ed95e, #9dff6e); }
+.bar.shield .bar-fill { background: #35b6ff; }
+.bar.health .bar-fill { background: #52d95e; }
 .bar span {
   position: absolute; inset: 0; display: grid; place-items: center;
   font-size: .72rem; font-weight: 800; color: #06280f; letter-spacing: .06em;
@@ -152,15 +220,26 @@ body {
 }
 .slot {
   width: clamp(52px, 7vw, 64px); aspect-ratio: 1;
-  display: grid; place-items: center; gap: 0;
-  background: rgba(11,21,48,.7); border: 2px solid rgba(255,255,255,.28); border-radius: 8px;
-  text-decoration: none; font-size: 1.3rem;
+  display: grid; place-items: center; align-content: center; gap: .2rem;
+  background: rgba(11,21,48,.78); border: 2px solid rgba(255,255,255,.28); border-radius: 4px;
+  text-decoration: none; color: #dbe3ff;
   transition: transform .12s ease, border-color .12s ease, background .12s ease;
 }
-.slot em { font-style: normal; font-size: .55rem; font-weight: 800; color: #dbe3ff; letter-spacing: .08em; text-transform: uppercase; }
-.slot:hover { transform: translateY(-4px); border-color: var(--gold); background: rgba(30,42,90,.85); }
+.slot .ico { width: 1.3rem; height: 1.3rem; }
+.slot em { font-style: normal; font-size: .55rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.slot:hover { transform: translateY(-4px); border-color: var(--gold); color: #fff; background: rgba(30,42,90,.92); }
 
-/* ============ MAP / POIs ============ */
+/* fan-content note */
+.fan-note {
+  position: absolute; bottom: .15rem; left: 50%; transform: translateX(-50%);
+  z-index: 20; margin: 0; padding: 0 1rem;
+  max-width: 92vw; text-align: center;
+  font-size: .58rem; font-weight: 600; color: rgba(219, 227, 255, .55);
+  pointer-events: auto;
+}
+.fan-note a { color: rgba(219, 227, 255, .7); }
+
+/* ============ FALLBACK MAP POIs ============ */
 .poi { cursor: pointer; outline: none; }
 .poi-hit {
   fill: #ffffff; fill-opacity: 0; stroke: #ffffff; stroke-opacity: 0;
@@ -187,15 +266,11 @@ body {
 .poi:hover .poi-label { fill: var(--gold); }
 
 .storm { pointer-events: none; }
-#stormCircle { filter: drop-shadow(0 0 14px rgba(123, 47, 247, .8)); }
-
-.battle-bus { pointer-events: none; opacity: 0; }
-.battle-bus.flying { opacity: 1; }
 
 /* ============ PANELS ============ */
 .panel-backdrop {
   position: fixed; inset: 0; z-index: 30;
-  background: rgba(5, 10, 28, .6); backdrop-filter: blur(3px);
+  background: rgba(5, 10, 28, .68);
 }
 .panel {
   position: fixed; z-index: 40;
@@ -203,10 +278,10 @@ body {
   width: min(860px, calc(100vw - 1.6rem));
   max-height: min(84vh, 900px);
   display: flex; flex-direction: column;
-  background: linear-gradient(170deg, var(--panel-2), var(--panel) 55%, #101a3e);
-  border: 2px solid rgba(255,255,255,.18);
-  border-radius: 10px;
-  box-shadow: 0 30px 80px rgba(0,0,0,.6), 0 0 0 6px rgba(123,47,247,.12);
+  background: var(--panel);
+  border: 2px solid var(--line);
+  clip-path: polygon(0 0, calc(100% - 22px) 0, 100% 22px, 100% 100%, 22px 100%, 0 calc(100% - 22px));
+  box-shadow: 10px 10px 0 rgba(5, 10, 28, .55);
   animation: panel-in .28s cubic-bezier(.2, 1.4, .4, 1);
 }
 @keyframes panel-in {
@@ -217,68 +292,71 @@ body {
 .panel-head {
   display: flex; justify-content: space-between; align-items: flex-start;
   padding: 1.1rem 1.3rem .9rem;
-  background: linear-gradient(90deg, rgba(123,47,247,.35), transparent 65%);
-  border-bottom: 2px solid rgba(255,255,255,.12);
-  border-radius: 8px 8px 0 0;
+  background: var(--panel-2);
+  border-bottom: 3px solid var(--gold);
 }
-.panel-head h2 { margin: 0; font-size: clamp(1.5rem, 4vw, 2.2rem); transform: skewX(-4deg); }
+.panel-head h2 { margin: 0; font-size: clamp(1.5rem, 4vw, 2.2rem); transform: skewX(-4deg); text-shadow: 3px 3px 0 #0b1530; }
 .panel-head p { margin: .2rem 0 0; color: var(--gold); font-weight: 800; font-size: .72rem; letter-spacing: .3em; }
 .panel-close {
   border: 2px solid rgba(255,255,255,.3); background: rgba(11,21,48,.6); color: var(--text);
-  width: 38px; height: 38px; border-radius: 8px; cursor: pointer; font-size: 1rem; font-weight: 800;
-  transition: border-color .12s ease, transform .12s ease;
+  width: 38px; height: 38px; border-radius: 3px; cursor: pointer;
+  display: grid; place-items: center;
+  transition: border-color .12s ease, color .12s ease;
 }
-.panel-close:hover { border-color: var(--gold); transform: rotate(90deg); }
+.panel-close .ico { width: 1.1rem; height: 1.1rem; }
+.panel-close:hover { border-color: var(--gold); color: var(--gold); }
 
 .panel-body { padding: 1.1rem 1.3rem 1.4rem; overflow-y: auto; display: grid; gap: 1rem; }
 
 /* quests (experience/education) */
 .quest {
-  border-radius: 10px; padding: 1rem 1.1rem;
-  background: rgba(11, 21, 48, .55);
-  border: 2px solid; border-image: none;
+  padding: 1rem 1.1rem;
+  background: var(--panel-2);
+  border: 2px solid; border-radius: 2px;
 }
-.quest.legendary { border-color: var(--legendary); box-shadow: inset 0 0 40px rgba(255,157,46,.08); }
-.quest.epic { border-color: var(--epic); box-shadow: inset 0 0 40px rgba(180,78,232,.08); }
-.quest.rare { border-color: var(--rare); box-shadow: inset 0 0 40px rgba(63,169,255,.08); }
+.quest.legendary { border-color: var(--legendary); }
+.quest.epic { border-color: var(--epic); }
+.quest.rare { border-color: var(--rare); }
 
 .quest-top { display: flex; justify-content: space-between; align-items: center; gap: .8rem; flex-wrap: wrap; }
 .quest h3 { margin: 0; font-size: 1.05rem; }
 .quest-meta { color: var(--muted); margin: .25rem 0 .6rem; font-size: .85rem; }
 .quest-list { list-style: none; margin: 0; padding: 0; display: grid; gap: .5rem; }
 .quest-list li { display: block; font-size: .92rem; line-height: 1.45; }
-.check { color: var(--uncommon); font-weight: 800; margin-right: .4rem; }
+.quest-list .check { color: var(--uncommon); margin-right: .35rem; }
 .xp { color: var(--gold); font-weight: 800; white-space: nowrap; margin-left: .3rem; }
 
 .rarity-pill {
-  font-size: .68rem; letter-spacing: .16em; padding: .28rem .6rem; border-radius: 4px; color: #1a1200;
-  background: linear-gradient(180deg, #ffe066, #ffb347);
+  font-size: .68rem; letter-spacing: .16em; padding: .28rem .6rem;
+  clip-path: polygon(8% 0, 100% 0, 92% 100%, 0 100%);
+  color: #1c1500; background: var(--gold);
 }
-.quest.epic .rarity-pill, .loot.epic .rarity-pill { background: linear-gradient(180deg, #d98aff, var(--epic)); color: #24063a; }
-.quest.rare .rarity-pill { background: linear-gradient(180deg, #8fd0ff, var(--rare)); color: #04263f; }
+.quest.legendary .rarity-pill, .loot.legendary .rarity-pill { background: var(--legendary); color: #2b1300; }
+.quest.epic .rarity-pill, .loot.epic .rarity-pill { background: var(--epic); color: #fff; }
+.quest.rare .rarity-pill { background: var(--rare); color: #04263f; }
 
 .xp-bar {
-  position: relative; height: 22px; border-radius: 5px; overflow: hidden; margin-top: .8rem;
+  position: relative; height: 22px; border-radius: 2px; overflow: hidden; margin-top: .8rem;
   background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.2);
 }
-.xp-fill { position: absolute; inset: 0; width: 94%; background: linear-gradient(90deg, #ffb347, var(--gold)); }
+.xp-fill { position: absolute; inset: 0; width: 94%; background: var(--gold); }
 .xp-bar span {
   position: absolute; inset: 0; display: grid; place-items: center;
-  font-size: .68rem; font-weight: 800; letter-spacing: .18em; color: #2d1c00;
+  font-size: .68rem; font-weight: 800; letter-spacing: .18em; color: #1c1500;
 }
 
 /* loot (projects) */
 .loot-grid { grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); align-items: stretch; }
 .loot {
   display: flex; flex-direction: column; gap: .5rem;
-  border-radius: 10px; padding: 1rem 1.1rem;
-  background: rgba(11, 21, 48, .55);
-  border: 2px solid;
-  transition: transform .15s ease, box-shadow .15s ease;
+  padding: 1rem 1.1rem;
+  background: var(--panel-2);
+  border: 2px solid; border-radius: 2px;
+  transition: transform .15s ease;
 }
 .loot:hover { transform: translateY(-4px); }
-.loot.legendary { border-color: var(--legendary); box-shadow: 0 0 24px rgba(255,157,46,.25); }
-.loot.epic { border-color: var(--epic); box-shadow: 0 0 24px rgba(180,78,232,.2); }
+.loot.legendary { border-color: var(--legendary); box-shadow: 5px 5px 0 rgba(233, 141, 75, .25); }
+.loot.epic { border-color: var(--epic); box-shadow: 5px 5px 0 rgba(168, 85, 247, .22); }
 .loot .rarity-pill { align-self: flex-start; }
 .loot h3 { margin: .1rem 0 0; font-size: 1.02rem; }
 .loot p { margin: 0; color: var(--muted); font-size: .88rem; }
@@ -286,25 +364,26 @@ body {
 .loot .panel-btn { margin-top: auto; }
 
 .panel-btn {
-  display: inline-block; text-align: center; text-decoration: none; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; gap: .45rem;
+  text-align: center; text-decoration: none; cursor: pointer;
   font-weight: 800; font-size: .82rem; letter-spacing: .08em;
-  color: var(--text); padding: .6rem .9rem; border-radius: 6px;
-  background: rgba(255,255,255,.08); border: 2px solid rgba(255,255,255,.25);
+  color: var(--text); padding: .6rem .9rem; border-radius: 2px;
+  background: rgba(255,255,255,.07); border: 2px solid rgba(255,255,255,.3);
   transition: border-color .12s ease, background .12s ease;
 }
-.panel-btn:hover { border-color: var(--gold); background: rgba(255,255,255,.14); }
-.panel-btn.gold { background: linear-gradient(180deg, #ffe066, #ffb347); color: #3a2500; border-color: transparent; }
-.panel-btn.gold:hover { filter: brightness(1.06); }
+.panel-btn:hover { border-color: var(--gold); background: rgba(255,255,255,.12); }
+.panel-btn.gold { background: var(--gold); color: #1c1500; border-color: var(--gold-deep); box-shadow: 3px 3px 0 rgba(5,10,28,.5); }
+.panel-btn.gold:hover { background: #ffdc4d; }
 
 /* inventory (skills) */
 .inv-grid { display: flex; flex-wrap: wrap; gap: .55rem; }
 .inv {
-  padding: .5rem .85rem; border-radius: 6px; font-weight: 700; font-size: .88rem;
-  border: 2px solid; background: rgba(11,21,48,.6);
+  padding: .5rem .85rem; border-radius: 2px; font-weight: 700; font-size: .88rem;
+  border: 2px solid; background: var(--panel-2);
   transition: transform .12s ease;
 }
-.inv:hover { transform: translateY(-3px) scale(1.04); }
-.inv.legendary { border-color: var(--legendary); color: #ffcf9a; box-shadow: 0 0 14px rgba(255,157,46,.35); }
+.inv:hover { transform: translateY(-3px); }
+.inv.legendary { border-color: var(--legendary); color: #ffc89a; }
 .inv.epic { border-color: var(--epic); color: #e3b8f7; }
 .inv.rare { border-color: var(--rare); color: #b5dcff; }
 .inv.uncommon { border-color: var(--uncommon); color: #c2f2c8; }
@@ -316,9 +395,8 @@ body {
 .chest-btn {
   display: grid; place-items: center; gap: .4rem;
   background: none; border: none; cursor: pointer; color: var(--gold);
-  font-family: Anton, Inter, sans-serif; font-size: 1rem; letter-spacing: .2em;
+  font-size: 1rem; letter-spacing: .2em;
   animation: chest-bob 2.2s ease-in-out infinite;
-  filter: drop-shadow(0 0 18px rgba(255, 213, 77, .45));
   transition: transform .15s ease;
 }
 .chest-btn:hover { transform: scale(1.06); }
@@ -335,12 +413,12 @@ body {
 /* about */
 .about-card { display: flex; gap: 1.1rem; align-items: flex-start; flex-wrap: wrap; }
 .about-avatar {
-  flex: 0 0 auto; width: 92px; height: 92px; border-radius: 12px;
+  flex: 0 0 auto; width: 92px; height: 92px; border-radius: 4px;
   display: grid; place-items: center;
   font-family: Anton, Inter, sans-serif; font-size: 2rem;
-  background: linear-gradient(160deg, #7b2ff7, #b44ee8);
+  background: var(--storm);
   border: 3px solid var(--gold);
-  box-shadow: 0 0 24px rgba(180,78,232,.5);
+  box-shadow: 5px 5px 0 rgba(5,10,28,.5);
 }
 .about-card > div { flex: 1 1 260px; }
 .about-card h3 { margin: 0; font-size: 1.3rem; }
@@ -350,27 +428,26 @@ body {
 .stat-row { display: grid; grid-template-columns: 130px 1fr auto; gap: .6rem; align-items: center; }
 .stat-row span { font-size: .68rem; font-weight: 800; letter-spacing: .14em; color: #cfd9ff; }
 .stat-row em { font-size: .7rem; color: var(--muted); }
-.stat-bar { height: 10px; border-radius: 99px; background: rgba(255,255,255,.1); overflow: hidden; }
-.stat-bar i { display: block; height: 100%; border-radius: 99px; background: linear-gradient(90deg, #35b6ff, #9dff6e); }
+.stat-bar { height: 10px; border-radius: 2px; background: rgba(255,255,255,.1); overflow: hidden; }
+.stat-bar i { display: block; height: 100%; background: #35b6ff; }
 
 /* ============ VICTORY ============ */
 .victory {
   position: fixed; inset: 0; z-index: 50; display: grid; place-items: center;
-  background: rgba(5, 10, 28, .72); backdrop-filter: blur(4px);
+  background: rgba(5, 10, 28, .78);
 }
 .victory-inner {
   text-align: center; padding: 2.4rem 2rem;
   animation: panel-in .4s cubic-bezier(.2, 1.4, .4, 1);
 }
-.victory-hash { margin: 0; font-size: clamp(2rem, 6vw, 3.4rem); color: var(--gold); text-shadow: 0 4px 0 rgba(0,0,0,.35); }
+.victory-hash { margin: 0; font-size: clamp(2rem, 6vw, 3.4rem); color: var(--gold); text-shadow: 3px 3px 0 #0b1530; }
 .victory-title {
   margin: 0; font-size: clamp(3rem, 10vw, 6.4rem); line-height: 1;
   transform: skewX(-6deg);
-  background: linear-gradient(180deg, #fff6c9, var(--gold) 55%, #ffb347);
-  -webkit-background-clip: text; background-clip: text; color: transparent;
-  filter: drop-shadow(0 6px 0 rgba(0,0,0,.35));
+  color: var(--gold);
+  text-shadow: 6px 6px 0 #0b1530;
 }
-.victory-sub { color: #e8ddff; font-weight: 700; margin: 1rem 0 1.6rem; }
+.victory-sub { color: #dbe3ff; font-weight: 700; margin: 1rem 0 1.6rem; }
 .victory .panel-btn.gold { font-size: 1rem; padding: .8rem 1.4rem; }
 .victory-close {
   display: block; margin: 1.2rem auto 0; background: none; border: none; cursor: pointer;
@@ -396,8 +473,9 @@ body {
   .poi-label { font-size: 40px; }
   .poi-tag { font-size: 22px; }
   .stat-row { grid-template-columns: 100px 1fr auto; }
+  .fan-note { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .lobby-sky::after, .compass-strip, .chest-btn { animation: none; }
+  .compass-strip, .chest-btn { animation: none; }
 }


### PR DESCRIPTION
## Summary
Added a complete Fortnite-themed alternative portfolio experience in the `fortnite/` directory. This is a standalone, vanilla HTML/CSS/JS site that presents Ali's resume and contact information as an interactive game interface, featuring a playable island map with six points of interest (POIs) that unlock different sections of his portfolio.

## Key Changes

- **New Fortnite portfolio site** (`fortnite/index.html`, `fortnite/styles.css`, `fortnite/script.js`)
  - Lobby/loading screen with "DROP IN" button to enter the game
  - Interactive island map with real Fortnite Reload island imagery (loaded at runtime from `fortnite-archives`)
  - Fallback hand-drawn SVG island if the real map fails to load
  - Six explorable POIs (Tilted Towers, Pleasant Park, Retail Row, Lil' Loot Lake, Snobby Shoals, Lone Lodge) mapping to portfolio sections
  - Victory Royale screen triggered when all 6 POIs are cleared
  - Fortnite-style HUD elements: compass, minimap, health/shield bars, hotbar with contact links
  - Storm circle animation that shrinks and resets in cycles
  - Battle bus intro animation
  - Confetti burst effects on victory and chest opening

- **Portfolio content panels** for each POI:
  - **Experience** (Tilted Towers): Work history at Visa and Cronys
  - **Education** (Snobby Shoals): CU Boulder degree details
  - **Projects** (Pleasant Park): Notable projects with links
  - **Skills** (Retail Row): Technical skills organized by proficiency tier
  - **Contact** (Lil' Loot Lake): Interactive chest with email/GitHub/site links
  - **About** (Lone Lodge): Personal bio and photo

- **Design system** following Fortnite's flat UI aesthetic:
  - No gradients; hard-edged shadows and angled `clip-path` corners
  - Fortnite rarity color palette (Mythic, Legendary, Epic, Rare, Uncommon, Common)
  - Custom SVG icon sprite for all UI elements
  - Responsive layout using CSS custom properties and `clamp()`

- **Documentation** (`CLAUDE.md`): Guidelines for maintaining both portfolio sites and design rules for future updates

## Notable Implementation Details

- **Dual map modes**: Real map loads asynchronously from `fortnite-archives` with an 8-second timeout; falls back to original SVG island if unavailable
- **No bundling**: Pure vanilla HTML/CSS/JS with no build step or external dependencies
- **Epic Games compliance**: Fan-content disclaimer visible on page; no Epic imagery committed to repo
- **Accessibility**: Keyboard navigation for POIs, focus management, ARIA labels, reduced-motion support
- **Performance**: Lazy-loads map image, uses `requestAnimationFrame` for animations, minimal repaints
- **Resume sync**: Content mirrors Ali's current resume (Visa SWE, Cronys co-founder, CU Boulder grad May 2026)

https://claude.ai/code/session_01MQebcv6c3GrBbn83AtxQ9p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Fortnite-inspired interactive portfolio experience with lobby and game screens.
  - Explore portfolio sections through map locations, including experience, projects, skills, education, contact, and about.
  - Added interactive HUD elements, map modes, storm effects, battle bus animation, loot interactions, and victory progression.
  - Added responsive layouts and reduced-motion support.

- **Documentation**
  - Added a comprehensive guide covering site structure, design requirements, content constraints, and local testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->